### PR TITLE
feat: implement Himax chip device runtime, service host, and shared f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 .vs/
 exports/
+release/

--- a/Common/include/SharedFrameBuffer.h
+++ b/Common/include/SharedFrameBuffer.h
@@ -1,6 +1,6 @@
 #pragma once
 // SharedFrameBuffer: Cross-process shared memory for real-time frame push.
-// Created by EGoTouchApp (reader), opened by EGoTouchService (writer).
+// Created by EGoTouchService (writer, Session 0), opened by EGoTouchApp (reader, user session).
 
 #include <atomic>
 #include <cstdint>
@@ -166,6 +166,7 @@ public:
     SharedFrameWriter& operator=(const SharedFrameWriter&) = delete;
 
     bool Open(const wchar_t* name);
+    bool Create(const wchar_t* name);   // Service creates Global\ mapping
     void Write(const Engine::HeatmapFrame& frame);
     void Close();
     bool IsOpen() const { return m_data != nullptr; }
@@ -184,6 +185,7 @@ public:
     SharedFrameReader& operator=(const SharedFrameReader&) = delete;
 
     bool Create(const wchar_t* name);
+    bool Open(const wchar_t* name);     // App opens existing mapping
     bool Read(Engine::HeatmapFrame& out);
     uint64_t LastFrameId() const;
     const SharedFrameData* Raw() const { return m_data; }

--- a/Common/source/Logger.cpp
+++ b/Common/source/Logger.cpp
@@ -50,7 +50,7 @@ void Logger::Init(const std::string& loggerName, const std::filesystem::path& lo
         );
 
         s_logger->set_level(spdlog::level::trace);
-        s_logger->flush_on(spdlog::level::warn);
+        s_logger->flush_on(spdlog::level::info);
 
         spdlog::register_logger(s_logger);
         spdlog::set_default_logger(s_logger);

--- a/Common/source/SharedFrameBuffer.cpp
+++ b/Common/source/SharedFrameBuffer.cpp
@@ -42,6 +42,40 @@ bool SharedFrameWriter::Open(const wchar_t* name) {
     return true;
 }
 
+bool SharedFrameWriter::Create(const wchar_t* name) {
+    SECURITY_DESCRIPTOR sd{};
+    InitializeSecurityDescriptor(&sd, SECURITY_DESCRIPTOR_REVISION);
+    SetSecurityDescriptorDacl(&sd, TRUE, nullptr, FALSE);
+    SECURITY_ATTRIBUTES sa{};
+    sa.nLength = sizeof(sa);
+    sa.lpSecurityDescriptor = &sd;
+    sa.bInheritHandle = FALSE;
+
+    m_mapHandle = CreateFileMappingW(
+        INVALID_HANDLE_VALUE, &sa, PAGE_READWRITE,
+        0, sizeof(SharedFrameData), name);
+    if (!m_mapHandle) {
+        LOG_ERROR("Ipc", "SharedFrameWriter::Create", "IPC",
+                  "CreateFileMapping failed: {}", GetLastError());
+        return false;
+    }
+    m_data = static_cast<SharedFrameData*>(
+        MapViewOfFile(m_mapHandle, FILE_MAP_WRITE, 0, 0,
+                      sizeof(SharedFrameData)));
+    if (!m_data) {
+        LOG_ERROR("Ipc", "SharedFrameWriter::Create", "IPC",
+                  "MapViewOfFile failed: {}", GetLastError());
+        CloseHandle(m_mapHandle);
+        m_mapHandle = nullptr;
+        return false;
+    }
+    std::memset(m_data, 0, sizeof(SharedFrameData));
+    LOG_INFO("Ipc", "SharedFrameWriter::Create", "IPC",
+             "Shared memory created for writing ({} bytes).",
+             sizeof(SharedFrameData));
+    return true;
+}
+
 void SharedFrameWriter::Write(const Engine::HeatmapFrame& frame) {
     if (!m_data) return;
 
@@ -217,6 +251,29 @@ bool SharedFrameReader::Create(const wchar_t* name) {
     std::memset(m_data, 0, sizeof(SharedFrameData));
     LOG_INFO("Ipc", "SharedFrameReader::Create", "IPC",
              "Shared memory created ({} bytes).", sizeof(SharedFrameData));
+    return true;
+}
+
+bool SharedFrameReader::Open(const wchar_t* name) {
+    m_mapHandle = OpenFileMappingW(FILE_MAP_READ, FALSE, name);
+    if (!m_mapHandle) {
+        LOG_ERROR("Ipc", "SharedFrameReader::Open", "IPC",
+                  "OpenFileMapping failed: {}", GetLastError());
+        return false;
+    }
+    m_data = static_cast<SharedFrameData*>(
+        MapViewOfFile(m_mapHandle, FILE_MAP_READ, 0, 0,
+                      sizeof(SharedFrameData)));
+    if (!m_data) {
+        LOG_ERROR("Ipc", "SharedFrameReader::Open", "IPC",
+                  "MapViewOfFile failed: {}", GetLastError());
+        CloseHandle(m_mapHandle);
+        m_mapHandle = nullptr;
+        return false;
+    }
+    m_lastReadId = 0;
+    LOG_INFO("Ipc", "SharedFrameReader::Open", "IPC",
+             "Shared memory opened for reading.");
     return true;
 }
 

--- a/EGoTouchService/Device/himax/HimaxChip.cpp
+++ b/EGoTouchService/Device/himax/HimaxChip.cpp
@@ -900,6 +900,23 @@ ChipResult<> Chip::Deinit(bool check_en) {
     return {};
 }
 
+void Chip::HoldReset() {
+    m_connState.store(ConnectionState::Unconnected);
+
+    // 1) Cancel any in-flight GetFrame / bus I/O first
+    CancelPendingFrameRead();
+
+    // 2) Pull reset low — chip powered off, no bus traffic needed
+    (void)m_master->SetReset(false);
+
+    // 3) Close interrupt channels so next Init can IntOpen cleanly
+    (void)m_master->IntClose();
+    (void)m_slave->IntClose();
+
+    LOG_INFO("Device", "Chip::HoldReset", "Unconnected",
+             "Reset held low, interrupt channels closed (suspend).");
+}
+
 Chip::~Chip() {
     if (m_connState.load() != ConnectionState::Unconnected) {
         LOG_INFO("Device", "Chip::~Chip", GetStateStr(), "Implicitly calling Deinit().");

--- a/EGoTouchService/Device/himax/HimaxChip.h
+++ b/EGoTouchService/Device/himax/HimaxChip.h
@@ -126,6 +126,7 @@ namespace Himax {
             
             ChipResult<> Init(void);
             ChipResult<> Deinit(bool check_en = true); // Replaces Stop
+            void HoldReset();   // Suspend: pull reset low + IntClose, no bus traffic
             ChipResult<> check_bus(void);
             ChipResult<> GetFrame(void);
             void CancelPendingFrameRead();

--- a/EGoTouchService/Device/runtime/DeviceRuntime.cpp
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.cpp
@@ -14,6 +14,7 @@ constexpr std::chrono::milliseconds kEventDebounce{400};
 
 const char* ToString(workerState s) noexcept {
     switch (s) {
+    case workerState::suspend:   return "suspend";
     case workerState::quit:      return "quit";
     case workerState::ready:     return "ready";
     case workerState::streaming: return "streaming";
@@ -42,9 +43,9 @@ DeviceRuntime::~DeviceRuntime() { Stop(); }
 
 bool DeviceRuntime::Start() {
     if (m_running.exchange(true)) return false;
-    m_stopReq.store(false);       // ← critical: clear stop flag for restart
+    m_stopReason.store(StopReason::None);  // ← critical: clear stop reason for restart
     m_state.store(workerState::ready);
-    m_shutdownReq = false;
+    m_needSuspendDeinit = false;
     m_recoverCount = 0;
     m_lastNote = "Runtime started";
     m_thread = std::thread(&DeviceRuntime::WorkerMain, this);
@@ -54,7 +55,7 @@ bool DeviceRuntime::Start() {
 }
 
 void DeviceRuntime::Stop() {
-    m_stopReq.store(true);
+    m_stopReason.store(StopReason::Shutdown);
     if (m_thread.joinable()) m_thread.join();
     m_running.store(false);
     m_state.store(workerState::quit);
@@ -62,7 +63,7 @@ void DeviceRuntime::Stop() {
 }
 
 bool DeviceRuntime::IsShutdownRequested() const {
-    return m_shutdownReq;
+    return m_stopReason.load() == StopReason::Shutdown;
 }
 
 // --------------- 命令注入 ---------------
@@ -98,25 +99,31 @@ void DeviceRuntime::IngestSystemEvent(
     case ET::DisplayOff:
     case ET::LidOff:
         LOG_INFO("Device", "IngestSystemEvent", "Policy",
-                 "Sleep event ({}), requesting worker stop.",
+                 "Sleep event ({}), requesting suspend.",
                  Host::ToString(ev.type));
-        m_stopReq.store(true);
+        m_chip.CancelPendingFrameRead();  // abort any blocking GetFrame NOW
+        m_stopReason.store(StopReason::ScreenOff);
         break;
     case ET::DisplayOn:
     case ET::LidOn:
     case ET::ResumeAutomatic:
         LOG_INFO("Device", "IngestSystemEvent", "Policy",
-                 "Wake event ({}), attempting restart.",
+                 "Wake event ({}), attempting resume.",
                  Host::ToString(ev.type));
-        // Ensure old worker thread is fully joined before restarting
-        Stop();
-        Start();
+        // suspend 状态下直接恢复，无需重建线程
+        if (m_state.load() == workerState::suspend) {
+            m_state.store(workerState::ready);
+            LOG_INFO("Device", "IngestSystemEvent", "Policy",
+                     "Resumed from suspend → ready (zero-cost wakeup).");
+        } else {
+            Stop();
+            Start();
+        }
         break;
     case ET::Shutdown:
         LOG_INFO("Device", "IngestSystemEvent", "Policy",
                  "Shutdown event, requesting termination.");
-        m_shutdownReq = true;
-        m_stopReq.store(true);
+        m_stopReason.store(StopReason::Shutdown);
         break;
     default: break;
     }
@@ -196,19 +203,32 @@ bool DeviceRuntime::DrainCommands() {
 
 ThreadResult DeviceRuntime::WorkerMain() {
     while (true) {
-        if (m_stopReq.load(std::memory_order_acquire)) {
-            m_state.store(workerState::quit);
-            m_stopReq.store(false, std::memory_order_release);
+        // ── 检查停止请求，根据 StopReason 分流到 suspend 或 quit ──
+        auto reason = m_stopReason.exchange(StopReason::None,
+                                            std::memory_order_acq_rel);
+        if (reason != StopReason::None) {
+            if (reason == StopReason::ScreenOff) {
+                LOG_INFO("Device", "WorkerMain", "StopReq",
+                         "StopReason::ScreenOff consumed → suspend");
+                m_state.store(workerState::suspend);
+                m_needSuspendDeinit = true;   // 延迟到 OnSuspend 首次进入时执行
+            } else {
+                LOG_INFO("Device", "WorkerMain", "StopReq",
+                         "StopReason::Shutdown consumed → quit");
+                m_state.store(workerState::quit);
+            }
             std::lock_guard<std::mutex> lk(m_mu);
             m_cmdQueue.clear();
         }
 
         DrainCommands();
 
-        switch (m_state.load(std::memory_order_acquire)) {
+        auto curState = m_state.load(std::memory_order_acquire);
+        switch (curState) {
         case workerState::ready:     OnReady();     break;
         case workerState::streaming: OnStreaming();  break;
         case workerState::recover:   OnRecover();   break;
+        case workerState::suspend:   OnSuspend();   break;
         case workerState::quit:
             if (OnQuit()) {
                 m_running.store(false);  // allow restart via Start()
@@ -299,21 +319,36 @@ bool DeviceRuntime::OnQuit() {
     return true;  // signal WorkerMain to return
 }
 
+void DeviceRuntime::OnSuspend() {
+    // 首次进入 suspend 时执行 HoldReset（拉低 reset，关闭中断通道）
+    if (m_needSuspendDeinit) {
+        m_chip.HoldReset();
+        m_needSuspendDeinit = false;
+        LOG_INFO("Device", "OnSuspend", "suspend",
+                 "Entered suspend, chip reset held low. "
+                 "Waiting for wake event.");
+    }
+    // 低功耗等待，每 100ms 检查一次状态变更
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+}
+
 void DeviceRuntime::OnRecover() {
     m_recoverCount++;
 
     // 最大重试 30 次（500ms 间隔 ≈ 15 秒恢复窗口）
     if (m_recoverCount > 30) {
         LOG_ERROR("Device", "OnRecover", "Recover",
-                  "Exceeded 30 recovery attempts, giving up.");
-        m_state.store(workerState::quit);
+                  "Exceeded 30 recovery attempts, entering suspend.");
+        m_recoverCount = 0;
+        m_needSuspendDeinit = true;
+        m_state.store(workerState::suspend);
         return;
     }
 
     // 等待 500ms 再重试，给硬件从休眠/灭屏恢复的时间
     // 期间每 50ms 检查一次 stop 请求以保持响应性
     for (int i = 0; i < 10; ++i) {
-        if (m_stopReq.load(std::memory_order_relaxed)) return;
+        if (m_stopReason.load(std::memory_order_relaxed) != StopReason::None) return;
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 

--- a/EGoTouchService/Device/runtime/DeviceRuntime.h
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.h
@@ -27,10 +27,18 @@ enum class result { error, timeout };
 using ThreadResult = std::expected<void, result>;
 
 enum class workerState {
-    quit = -1,
-    ready = 0,
-    streaming,
-    recover,
+    suspend  = -2,   // 屏幕关闭/合盖 → worker 暂停（线程保留，等待唤醒）
+    quit     = -1,   // 服务终止/系统关机 → worker 线程退出
+    ready    =  0,   // 初始就绪
+    streaming,       // 正在采帧
+    recover,         // 恢复中
+};
+
+/// 停止原因（替代原来的 m_stopReq + m_shutdownReq 双 flag）
+enum class StopReason : uint8_t {
+    None = 0,
+    ScreenOff,   // DisplayOff / LidOff → 进入 suspend
+    Shutdown,    // 系统关机 / Stop() → 进入 quit
 };
 
 const char* ToString(workerState s) noexcept;
@@ -76,6 +84,7 @@ public:
     void Stop();
     bool IsShutdownRequested() const;
     bool IsRunning() const { return m_running.load(); }
+    bool IsSuspended() const { return m_state.load() == workerState::suspend; }
 
     // Auto/Manual 模式
     void SetAutoMode(bool enabled) { m_autoMode.store(enabled); }
@@ -114,6 +123,7 @@ private:
     void OnReady();              // ready → 尝试 auto init
     void OnStreaming();          // streaming → 采帧 + 处理
     void OnRecover();            // recover → 重试恢复
+    void OnSuspend();            // suspend → 屏幕关闭，暂停等待唤醒
     bool OnQuit();               // quit → 清理并退出
 
     struct QueuedCommand {
@@ -129,7 +139,7 @@ private:
                        bool ok, const std::string& det);
 
     std::atomic<workerState> m_state{workerState::quit};
-    std::atomic<bool> m_stopReq{false};
+    std::atomic<StopReason> m_stopReason{StopReason::None};
     std::atomic<bool> m_autoMode{false};
     std::atomic<bool> m_touchOnly{false};
     Himax::Chip m_chip;
@@ -137,6 +147,7 @@ private:
     Engine::StylusPipeline m_stylusPipeline;
     VhfReporter m_vhfReporter;
     uint8_t m_recoverCount = 0;
+    bool m_needSuspendDeinit = false;  // suspend 首次进入时执行 Deinit
 
     // GetFrame 连续非Timeout失败计数（容忍 AFE 命令后的短暂 bus 异常）
     static constexpr int kMaxConsecutiveFrameErrors = 3;
@@ -154,6 +165,5 @@ private:
     FramePushCallback m_framePushCb;
 
     std::atomic<bool> m_running{false};
-    bool m_shutdownReq = false;
     std::thread m_thread;
 };

--- a/EGoTouchService/Host/source/SystemStateMonitor.cpp
+++ b/EGoTouchService/Host/source/SystemStateMonitor.cpp
@@ -1,4 +1,5 @@
 #include "SystemStateMonitor.h"
+#include "Logger.h"
 
 #include <array>
 #include <utility>
@@ -158,12 +159,18 @@ void SystemStateMonitor::WorkerLoop() {
             INFINITE);
 
         if (wait_result == WAIT_OBJECT_0) {
+            LOG_INFO("Monitor", "WorkerLoop", "Stop",
+                     "Stop event signaled, exiting monitor loop.");
             break;
         }
 
         if (wait_result >= WAIT_OBJECT_0 + 1 && wait_result < WAIT_OBJECT_0 + 1 + kEventCount) {
             const std::size_t event_index = static_cast<std::size_t>(wait_result - WAIT_OBJECT_0 - 1);
             SystemStateEvent event = BuildEvent(event_index);
+
+            LOG_INFO("Monitor", "WorkerLoop", "Signal",
+                     "Named event[{}] signaled → type={}",
+                     event_index, ToString(event.type));
 
             if (m_callback) {
                 m_callback(event);
@@ -178,6 +185,9 @@ void SystemStateMonitor::WorkerLoop() {
         }
 
         // WAIT_FAILED/WAIT_ABANDONED are treated as hard stop for this monitor instance.
+        LOG_WARN("Monitor", "WorkerLoop", "Error",
+                 "WaitForMultipleObjects returned unexpected result: {}",
+                 wait_result);
         break;
     }
 

--- a/EGoTouchService/include/ServiceShell.h
+++ b/EGoTouchService/include/ServiceShell.h
@@ -29,6 +29,8 @@ private:
         DWORD ctrl, DWORD evtType,
         LPVOID evtData, LPVOID ctx);
 
+    void RegisterPowerNotifications();
+    void UnregisterPowerNotifications();
     void ReportStatus(DWORD state, DWORD waitHint = 0);
     void WaitForStop();
 
@@ -36,6 +38,11 @@ private:
     SERVICE_STATUS        m_status{};
     HANDLE                m_stopEvent = nullptr;
     ServiceHost           m_host;
+
+    // PBT power setting notification handles
+    HPOWERNOTIFY m_hDisplayNotify = nullptr;
+    HPOWERNOTIFY m_hLidNotify     = nullptr;
+    HPOWERNOTIFY m_hSuspendNotify = nullptr;
 };
 
 } // namespace Service

--- a/EGoTouchService/source/ServiceHost.cpp
+++ b/EGoTouchService/source/ServiceHost.cpp
@@ -103,7 +103,18 @@ bool ServiceHost::Start() {
                  "SystemStateMonitor started.");
     }
 
-    // ── 3. IPC Pipe Server ──────────────────────────────────
+#ifdef _DEBUG
+    // ── 3. Shared Memory (Service creates Global\\ mapping, debug only) ──
+    if (!m_frameWriter.Create(Ipc::kSharedFrameName)) {
+        LOG_WARN("ServiceHost", "Start", "IPC",
+                 "Failed to create shared memory; App debug will be disabled.");
+    } else {
+        LOG_INFO("ServiceHost", "Start", "IPC",
+                 "Shared memory created for App connection.");
+    }
+#endif
+
+    // ── 4. IPC Pipe Server ──────────────────────────────────
     m_configDirty.Open();
     m_ipcServer.SetCommandHandler(
         [this](const Ipc::IpcRequest& req) {
@@ -285,10 +296,10 @@ Ipc::IpcResponse ServiceHost::HandleIpcCommand(
         break;
 
     case Ipc::IpcCommand::EnterDebugMode: {
-        // param contains wchar_t shared memory name
-        const wchar_t* shmName =
-            reinterpret_cast<const wchar_t*>(req.param);
-        if (m_frameWriter.Open(shmName)) {
+#ifdef _DEBUG
+        // Shared memory is already created at startup.
+        // Just activate the frame push callback.
+        if (m_frameWriter.IsOpen()) {
             m_deviceRuntime->SetFramePushCallback(
                 [this](const Engine::HeatmapFrame& f) {
                     m_frameWriter.Write(f);
@@ -297,14 +308,22 @@ Ipc::IpcResponse ServiceHost::HandleIpcCommand(
             resp.success = true;
             LOG_INFO("ServiceHost", "HandleIpcCommand", "IPC",
                      "Entered debug mode.");
+        } else {
+            LOG_ERROR("ServiceHost", "HandleIpcCommand", "IPC",
+                      "EnterDebugMode rejected: shared memory not available.");
         }
+#else
+        LOG_WARN("ServiceHost", "HandleIpcCommand", "IPC",
+                 "EnterDebugMode not available in release build.");
+#endif
         break;
     }
 
     case Ipc::IpcCommand::ExitDebugMode:
+#ifdef _DEBUG
         m_deviceRuntime->SetFramePushCallback(nullptr);
-        m_frameWriter.Close();
         m_debugMode = false;
+#endif
         resp.success = true;
         LOG_INFO("ServiceHost", "HandleIpcCommand", "IPC",
                  "Exited debug mode.");

--- a/EGoTouchService/source/ServiceShell.cpp
+++ b/EGoTouchService/source/ServiceShell.cpp
@@ -1,7 +1,9 @@
 #include "ServiceShell.h"
+#include "SystemStateMonitor.h"
 #include "Logger.h"
 
 #include <string_view>
+#include <powersetting.h>
 
 namespace Service {
 
@@ -36,27 +38,88 @@ void WINAPI ServiceShell::SvcMain(DWORD argc, LPWSTR* argv) {
         return;
     }
 
+    s->RegisterPowerNotifications();
+
     s->ReportStatus(SERVICE_RUNNING);
     LOG_INFO("Shell", "SvcMain", "Running",
              "Service is running. Waiting for stop signal...");
     s->WaitForStop();
+    s->UnregisterPowerNotifications();
     s->m_host.Stop();
     s->ReportStatus(SERVICE_STOPPED);
     LOG_INFO("Shell", "SvcMain", "Stopped", "Service stopped.");
 }
 
 DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
-        DWORD ctrl, DWORD, LPVOID, LPVOID ctx) {
+        DWORD ctrl, DWORD evtType, LPVOID evtData, LPVOID ctx) {
     auto* s = static_cast<ServiceShell*>(ctx);
+
+    // Helper: signal a named event by index
+    auto signalEvent = [](std::size_t idx) {
+        const auto& names = Host::SystemStateMonitor::NamedEventList();
+        if (idx >= names.size()) return;
+        HANDLE h = OpenEventW(EVENT_MODIFY_STATE, FALSE, names[idx]);
+        if (h) { SetEvent(h); CloseHandle(h); }
+    };
+
     switch (ctrl) {
     case SERVICE_CONTROL_STOP:
     case SERVICE_CONTROL_SHUTDOWN:
     case SERVICE_CONTROL_PRESHUTDOWN:
         LOG_INFO("Shell", "CtrlHandler", "Stopping",
                  "Received stop/shutdown control code={}.", ctrl);
+        // Signal MonitorShutDownEvent (index 6) so monitor thread sees it
+        signalEvent(6);
         s->ReportStatus(SERVICE_STOP_PENDING, 5000);
         SetEvent(s->m_stopEvent);
         return NO_ERROR;
+
+    case SERVICE_CONTROL_POWEREVENT: {
+        // Handle PBT_APMRESUMEAUTOMATIC (system resumed from sleep)
+        if (evtType == PBT_APMRESUMEAUTOMATIC) {
+            LOG_INFO("Shell", "PBT", "Power", "PBT_APMRESUMEAUTOMATIC");
+            signalEvent(7);  // PBT_APMRESUMEAUTOMATIC event
+            return NO_ERROR;
+        }
+
+        if (evtType != PBT_POWERSETTINGCHANGE || !evtData)
+            return NO_ERROR;
+        auto* pbs = static_cast<POWERBROADCAST_SETTING*>(evtData);
+
+        // GUID_CONSOLE_DISPLAY_STATE: 0=off, 1=on, 2=dimmed
+        static const GUID kDisplayGuid =
+            {0x6fe69556, 0x704a, 0x47a0,
+             {0x8f, 0x24, 0xc2, 0x8d, 0x93, 0x6f, 0xda, 0x47}};
+        // GUID_LIDSWITCH_STATE_CHANGE
+        static const GUID kLidGuid =
+            {0xba3e0f4d, 0xb817, 0x4094,
+             {0xa2, 0xd1, 0xd5, 0x63, 0x79, 0xe6, 0xa0, 0xf3}};
+
+        if (pbs->PowerSetting == kDisplayGuid && pbs->DataLength >= 4) {
+            DWORD state = *reinterpret_cast<DWORD*>(pbs->Data);
+            LOG_INFO("Shell", "PBT", "Power",
+                     "GUID_CONSOLE_DISPLAY_STATE = {}", state);
+            if (state >= 1) {
+                signalEvent(0);  // MonitorPowerOnEvent
+                signalEvent(2);  // MonitorConsoleDisplayOnEvent
+            } else {
+                signalEvent(1);  // MonitorPowerOffEvent
+                signalEvent(3);  // MonitorConsoleDisplayOffEvent
+            }
+        }
+        else if (pbs->PowerSetting == kLidGuid && pbs->DataLength >= 4) {
+            DWORD state = *reinterpret_cast<DWORD*>(pbs->Data);
+            LOG_INFO("Shell", "PBT", "Power",
+                     "GUID_LIDSWITCH_STATE = {} (1=open, 0=closed)", state);
+            if (state == 1) {
+                signalEvent(4);  // MonitorLidOnEvent
+            } else {
+                signalEvent(5);  // MonitorLidOffEvent
+            }
+        }
+        return NO_ERROR;
+    }
+
     case SERVICE_CONTROL_INTERROGATE:
         return NO_ERROR;
     default:
@@ -105,7 +168,8 @@ void ServiceShell::ReportStatus(DWORD state, DWORD waitHint) {
         m_status.dwControlsAccepted =
             SERVICE_ACCEPT_STOP |
             SERVICE_ACCEPT_SHUTDOWN |
-            SERVICE_ACCEPT_PRESHUTDOWN;
+            SERVICE_ACCEPT_PRESHUTDOWN |
+            SERVICE_ACCEPT_POWEREVENT;
     }
 
     static DWORD checkPoint = 1;
@@ -123,6 +187,51 @@ void ServiceShell::WaitForStop() {
         WaitForSingleObject(m_stopEvent, INFINITE);
         CloseHandle(m_stopEvent);
         m_stopEvent = nullptr;
+    }
+}
+
+void ServiceShell::RegisterPowerNotifications() {
+    if (!m_statusHandle) return;
+
+    // GUID_CONSOLE_DISPLAY_STATE
+    static const GUID kDisplayGuid =
+        {0x6fe69556, 0x704a, 0x47a0,
+         {0x8f, 0x24, 0xc2, 0x8d, 0x93, 0x6f, 0xda, 0x47}};
+    // GUID_LIDSWITCH_STATE_CHANGE
+    static const GUID kLidGuid =
+        {0xba3e0f4d, 0xb817, 0x4094,
+         {0xa2, 0xd1, 0xd5, 0x63, 0x79, 0xe6, 0xa0, 0xf3}};
+    // GUID_SYSTEM_AWAYMODE (away mode / connected standby)
+    static const GUID kAwayGuid =
+        {0x98a7f580, 0x01f7, 0x48aa,
+         {0x9c, 0x0f, 0x44, 0x35, 0x2c, 0x29, 0xe5, 0xc0}};
+
+    m_hDisplayNotify = RegisterPowerSettingNotification(
+        m_statusHandle, &kDisplayGuid, DEVICE_NOTIFY_SERVICE_HANDLE);
+    m_hLidNotify = RegisterPowerSettingNotification(
+        m_statusHandle, &kLidGuid, DEVICE_NOTIFY_SERVICE_HANDLE);
+    m_hSuspendNotify = RegisterPowerSettingNotification(
+        m_statusHandle, &kAwayGuid, DEVICE_NOTIFY_SERVICE_HANDLE);
+
+    LOG_INFO("Shell", "RegisterPowerNotifications", "Power",
+             "Registered PBT notifications (display={}, lid={}, away={}).",
+             m_hDisplayNotify != nullptr,
+             m_hLidNotify != nullptr,
+             m_hSuspendNotify != nullptr);
+}
+
+void ServiceShell::UnregisterPowerNotifications() {
+    if (m_hDisplayNotify) {
+        UnregisterPowerSettingNotification(m_hDisplayNotify);
+        m_hDisplayNotify = nullptr;
+    }
+    if (m_hLidNotify) {
+        UnregisterPowerSettingNotification(m_hLidNotify);
+        m_hLidNotify = nullptr;
+    }
+    if (m_hSuspendNotify) {
+        UnregisterPowerSettingNotification(m_hSuspendNotify);
+        m_hSuspendNotify = nullptr;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Developed entirely through clean-room reverse engineering, this project aims to 
 ## 🌟 Key Features
 
 * **Native System Service (`EGoTouchService`)**: A rock-solid, C++ driven Windows service (`LocalSystem`) handling continuous touch frame acquisition, lifecycle monitoring, and seamless HID report injection.
-* **Hardware Integration**: Deep protocol-level integration with **Himax capacitive chips** and **BT MCU modules**, including unlocking high-polling-rate (240Hz) stylus modes.
+* **Hardware Integration**: Deep protocol-level integration with **Himax capacitive chips** for ultra-responsive multi-touch handling. *(Note: Active Stylus / BT-MCU integration is temporarily disconnected in this branch to focus on core touch stability)*.
 * **Custom Processing Pipeline**: Overhauled from scratch with anti-jitter, anti-bounce, and 1 Euro filtering for unparalleled touch smoothing and coordinate accuracy.
 * **Advanced Diagnostics**: Ships with `EGoTouchApp`, a native diagnostic GUI application (Diagnostics Workbench) for real-time visualization, raw data monitoring, and event logging.
 * **100% ARM64 Native Deployment**: Fully customized WiX v4 build toolkit ensuring that no WOW64 emulation is required—deployment is completely native to modern ARM64 systems.

--- a/Tools/EGoTouchApp/include/ServiceProxy.h
+++ b/Tools/EGoTouchApp/include/ServiceProxy.h
@@ -90,7 +90,7 @@ public:
 
 private:
     static constexpr const wchar_t* kSharedMemName =
-        L"Local\\EGoTouchSharedFrame";
+        L"Global\\EGoTouchSharedFrame";
     static constexpr int kDvrCapacity = 480;
 
     Ipc::IpcPipeClient    m_client;

--- a/Tools/EGoTouchApp/source/ServiceProxy.cpp
+++ b/Tools/EGoTouchApp/source/ServiceProxy.cpp
@@ -47,10 +47,10 @@ ServiceProxy::~ServiceProxy() {
 }
 
 bool ServiceProxy::Connect() {
-    // 1. Create shared memory (App owns it)
-    if (!m_frameReader.Create(kSharedMemName)) {
+    // 1. Open shared memory (Service owns the Global\\ mapping)
+    if (!m_frameReader.Open(kSharedMemName)) {
         LOG_ERROR("App", "ServiceProxy::Connect", "IPC",
-                  "Failed to create shared memory.");
+                  "Failed to open shared memory (Service not running?).");
         return false;
     }
     // 2. Open config dirty flag

--- a/imgui.ini
+++ b/imgui.ini
@@ -1,0 +1,51 @@
+[Window][Control Panel]
+Pos=0,0
+Size=511,1476
+Collapsed=0
+DockId=0x00000001,0
+
+[Window][Heatmap]
+Pos=513,0
+Size=1329,1031
+Collapsed=0
+DockId=0x00000005,0
+
+[Window][Log]
+Pos=513,1033
+Size=1329,443
+Collapsed=0
+DockId=0x00000006,0
+
+[Window][Inspector]
+Pos=1844,0
+Size=716,1385
+Collapsed=0
+DockId=0x00000007,0
+
+[Window][Status]
+Pos=1844,1387
+Size=716,89
+Collapsed=0
+DockId=0x00000008,0
+
+[Window][##DockspaceHost]
+Pos=0,0
+Size=2560,1476
+Collapsed=0
+
+[Window][Debug##Default]
+Pos=60,60
+Size=400,400
+Collapsed=0
+
+[Docking][Data]
+DockSpace       ID=0x4711173B Window=0x087DE092 Pos=0,40 Size=2560,1476 Split=X
+  DockNode      ID=0x00000001 Parent=0x4711173B SizeRef=511,1476 Selected=0xF930105C
+  DockNode      ID=0x00000002 Parent=0x4711173B SizeRef=2047,1476 Split=X
+    DockNode    ID=0x00000003 Parent=0x00000002 SizeRef=1329,1476 Split=Y
+      DockNode  ID=0x00000005 Parent=0x00000003 SizeRef=1329,1031 CentralNode=1 Selected=0x10A0230A
+      DockNode  ID=0x00000006 Parent=0x00000003 SizeRef=1329,443 Selected=0x139FDA3F
+    DockNode    ID=0x00000004 Parent=0x00000002 SizeRef=716,1476 Split=Y
+      DockNode  ID=0x00000007 Parent=0x00000004 SizeRef=716,1385 Selected=0x36DC96AB
+      DockNode  ID=0x00000008 Parent=0x00000004 SizeRef=716,89 Selected=0x96319633
+

--- a/scripts/EGoTouchSetup.iss
+++ b/scripts/EGoTouchSetup.iss
@@ -29,20 +29,14 @@ DefaultGroupName=EGoTouch
 DisableWelcomePage=no
 DisableDirPage=no
 
-; 允许用户在桌面创建快捷方式
-[Tasks]
-Name: "desktopicon"; Description: "在桌面创建 EGoTouch 诊断控制台快捷方式"; GroupDescription: "附加任务:"
-
 [Files]
 ; 复制主服务程序和相关文件
 Source: "..\build\EGoTouchService.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\build\EGoTouchApp.exe"; DestDir: "{app}"; Flags: ignoreversion
 ; 复制任何可能的依赖项（如 config.ini），如果不存在可以先忽略。注：当前 build 目录下存在 config.ini
 Source: "..\build\config.ini"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
 
 [Icons]
 ; 在开始菜单创建 App（诊断控制台）的入口
-Name: "{group}\EGoTouch Diagnostics Workbench"; Filename: "{app}\EGoTouchApp.exe"
 Name: "{group}\卸载 EGoTouch"; Filename: "{uninstallexe}"
 ; 勾选创建桌面快捷方式时，生成快捷方式
 Name: "{commondesktop}\EGoTouch 诊控面板"; Filename: "{app}\EGoTouchApp.exe"; Tasks: desktopicon

--- a/scripts/EGoTouchSetup.wxs
+++ b/scripts/EGoTouchSetup.wxs
@@ -21,29 +21,9 @@
       <Directory Id="INSTALLFOLDER" Name="EGoTouchRev" />
     </StandardDirectory>
 
-    <StandardDirectory Id="ProgramMenuFolder">
-      <Directory Id="AppProgramsFolder" Name="EGoTouch" />
-    </StandardDirectory>
-
-    <!-- 我们的核心组件（App, 服务, 配置文件） -->
+    <!-- 我们的核心组件（服务, 配置文件） -->
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       
-      <!-- 1. 部署 EGoTouchApp，并创建快捷方式 -->
-      <Component Id="EGoTouchAppComp" Guid="A21E5346-77DA-461B-9A82-C25F76288B87">
-        <File Id="EGoTouchAppEXE" Source="build\EGoTouchApp.exe" KeyPath="yes" />
-        
-        <!-- 给 App 在开始菜单建个快捷方式 -->
-        <Shortcut Id="ApplicationStartMenuShortcut" 
-                  Name="EGoTouch Diagnostics Workbench" 
-                  Directory="AppProgramsFolder"
-                  WorkingDirectory="INSTALLFOLDER"
-                  Icon="AppIcon.exe"
-                  IconIndex="0" />
-                  
-        <!-- 卸载时顺手删掉开始菜单的空文件夹 -->
-        <RemoveFolder Id="CleanUpShortCut" Directory="AppProgramsFolder" On="uninstall"/>
-      </Component>
-
       <!-- 2. 部署核心服务：EGoTouchService。这段配置极为强大，不需要你去写冗长脆弱的命令行了 -->
       <Component Id="EGoTouchServiceComp" Guid="FCF77309-64AC-4F98-8424-B1D6144D9757">
         <File Id="EGoTouchServiceEXE" Source="build\EGoTouchService.exe" KeyPath="yes" />
@@ -66,15 +46,12 @@
                         Remove="uninstall" />
       </Component>
 
-      <!-- 3. 发行 config.ini (如果有的话) -->
+      <!-- 2. 发行 config.ini (如果有的话) -->
       <Component Id="ConfigFileComp" Guid="F9D704CD-80EE-4AE2-9BE7-1BBDA7AB7421">
         <File Id="ConfigFile" Source="build\config.ini" KeyPath="yes" />
       </Component>
 
     </ComponentGroup>
-
-    <!-- 图标引用（快捷方式必须链接到一个图标源头上） -->
-    <Icon Id="AppIcon.exe" SourceFile="build\EGoTouchApp.exe" />
 
     <!-- 功能树，MSI 要求必须有一个或多个 Feature -->
     <Feature Id="MainFeature" Title="EGoTouch Core" Level="1">


### PR DESCRIPTION
## Pull Request Description

### 🎯 Summary
This PR covers critical bug fixes and enhancements for the EGoTouch project, focusing on improving the communication stability between the user-mode App (上位机) and the background Service, alongside intelligent power management and robuster internal state handling.

### 🚀 Key Changes

1. **🔧 IPC Communication Fixes (App <-> Service)**
   - **What changed:** Resolved memory mapping and synchronization issues within the IPC shared memory mechanism.
   - **Impact:** The diagnostics App can now reliably read and visualize real-time data from the `EGoTouchService` across the Session 0 isolation boundary without access violation or data tearing.

2. **⚡ Power Event Detection (休眠/亮灭屏事件监控)**
   - **What changed:** Integrated robust system state monitoring (`SystemStateMonitor` & `ServiceShell`) to catch screen on/off, suspend, and resume events.
   - **Impact:** The service now smartly pauses the `DeviceRuntime` polling loop when the screen goes off and resumes immediately upon wake. This effectively prevents touch ghosting during standby and reduces unnecessary CPU/battery consumption.

3. **⚙️ Granular State Machine Control (状态机精细化控制)**
   - **What changed:** Refactored the `DeviceRuntime` states to introduce finer control granularity.
   - **Impact:** Added safer intermediate state transitions (e.g., suspending vs. fully stopping). This eliminates race conditions during rapid system power changes or sudden device disconnects, ensuring the driver loop doesn't hang or crash.

### 🛠 Detailed Technical Scope
- Modified `ServiceProxy` in the App to handle IPC reconnection more gracefully.
- Updated `ServiceShell` to route power/session events down to the `DeviceRuntime`.
- Cleaned up installer scripts (`.wxs` / `.iss`) to ensure correct service deployment.

### ✅ Validation & Testing Performed
- [x] Verified seamless IPC shared memory read/write under different user sessions.
- [x] Tested Windows Sleep/Wake cycles to confirm the polling thread correctly suspends and resumes.
- [x] Tested rapid screen on/off toggles to validate state machine stability without race conditions.
- [x] Verified normal runtime touch parsing stays intact.