### PR TITLE
Refactor: Standardize logging macros 4-parameter signature

### DIFF
--- a/Common/source/IpcPipeClient.cpp
+++ b/Common/source/IpcPipeClient.cpp
@@ -8,9 +8,7 @@ bool IpcPipeClient::Connect(DWORD timeoutMs) {
     if (m_pipe != INVALID_HANDLE_VALUE) return true;
 
     if (!WaitNamedPipeW(kPipeName, timeoutMs)) {
-        LOG_ERROR("Ipc", "IpcPipeClient::Connect", "IPC",
-                  "No pipe server available (timeout={}ms).",
-                  timeoutMs);
+        LOG_ERROR("IPC", __func__, "IPC", "No pipe server available (timeout={}ms).",  timeoutMs);
         return false;
     }
 
@@ -18,8 +16,7 @@ bool IpcPipeClient::Connect(DWORD timeoutMs) {
         kPipeName, GENERIC_READ | GENERIC_WRITE,
         0, nullptr, OPEN_EXISTING, 0, nullptr);
     if (m_pipe == INVALID_HANDLE_VALUE) {
-        LOG_ERROR("Ipc", "IpcPipeClient::Connect", "IPC",
-                  "CreateFile failed: {}", GetLastError());
+        LOG_ERROR("IPC", __func__, "IPC", "CreateFile failed: {}",  GetLastError());
         return false;
     }
 
@@ -27,8 +24,7 @@ bool IpcPipeClient::Connect(DWORD timeoutMs) {
     DWORD mode = PIPE_READMODE_MESSAGE;
     SetNamedPipeHandleState(m_pipe, &mode, nullptr, nullptr);
 
-    LOG_INFO("Ipc", "IpcPipeClient::Connect", "IPC",
-             "Connected to service.");
+    LOG_INFO("IPC", __func__, "IPC", "Connected to service.");
     return true;
 }
 
@@ -45,16 +41,14 @@ IpcResponse IpcPipeClient::Send(const IpcRequest& req) {
 
     DWORD bytesWritten = 0;
     if (!WriteFile(m_pipe, &req, sizeof(req), &bytesWritten, nullptr)) {
-        LOG_ERROR("Ipc", "IpcPipeClient::Send", "IPC",
-                  "WriteFile failed: {}", GetLastError());
+        LOG_ERROR("IPC", __func__, "IPC", "WriteFile failed: {}",  GetLastError());
         Disconnect();
         return resp;
     }
 
     DWORD bytesRead = 0;
     if (!ReadFile(m_pipe, &resp, sizeof(resp), &bytesRead, nullptr)) {
-        LOG_ERROR("Ipc", "IpcPipeClient::Send", "IPC",
-                  "ReadFile failed: {}", GetLastError());
+        LOG_ERROR("IPC", __func__, "IPC", "ReadFile failed: {}",  GetLastError());
         Disconnect();
         return resp;
     }

--- a/Common/source/IpcPipeServer.cpp
+++ b/Common/source/IpcPipeServer.cpp
@@ -11,8 +11,7 @@ bool IpcPipeServer::Start() {
     if (m_running.load()) return true;
     m_running.store(true);
     m_thread = std::thread(&IpcPipeServer::ServerLoop, this);
-    LOG_INFO("Ipc", "IpcPipeServer::Start", "IPC",
-             "Pipe server started.");
+    LOG_INFO("IPC", __func__, "IPC", "Pipe server started.");
     return true;
 }
 
@@ -24,8 +23,7 @@ void IpcPipeServer::Stop() {
         0, nullptr, OPEN_EXISTING, 0, nullptr);
     if (h != INVALID_HANDLE_VALUE) CloseHandle(h);
     if (m_thread.joinable()) m_thread.join();
-    LOG_INFO("Ipc", "IpcPipeServer::Stop", "IPC",
-             "Pipe server stopped.");
+    LOG_INFO("IPC", __func__, "IPC", "Pipe server stopped.");
 }
 
 void IpcPipeServer::ServerLoop() {
@@ -48,8 +46,7 @@ void IpcPipeServer::ServerLoop() {
             1, sizeof(IpcResponse), sizeof(IpcRequest),
             0, &sa);
         if (pipe == INVALID_HANDLE_VALUE) {
-            LOG_ERROR("Ipc", "IpcPipeServer::ServerLoop", "IPC",
-                      "CreateNamedPipe failed: {}", GetLastError());
+            LOG_ERROR("IPC", __func__, "IPC", "CreateNamedPipe failed: {}",  GetLastError());
             break;
         }
 
@@ -61,8 +58,7 @@ void IpcPipeServer::ServerLoop() {
             CloseHandle(pipe);
             continue;
         }
-        LOG_INFO("Ipc", "IpcPipeServer::ServerLoop", "IPC",
-                 "Client connected.");
+        LOG_INFO("IPC", __func__, "IPC", "Client connected.");
 
         // Read/dispatch loop for this client
         while (m_running.load()) {
@@ -86,8 +82,7 @@ void IpcPipeServer::ServerLoop() {
 
         DisconnectNamedPipe(pipe);
         CloseHandle(pipe);
-        LOG_INFO("Ipc", "IpcPipeServer::ServerLoop", "IPC",
-                 "Client disconnected.");
+        LOG_INFO("IPC", __func__, "IPC", "Client disconnected.");
     }
 }
 

--- a/Common/source/SharedFrameBuffer.cpp
+++ b/Common/source/SharedFrameBuffer.cpp
@@ -22,8 +22,7 @@ bool SharedFrameWriter::Open(const wchar_t* name) {
         sa.bInheritHandle = FALSE;
         m_mapHandle = OpenFileMappingW(FILE_MAP_WRITE, FALSE, name);
         if (!m_mapHandle) {
-            LOG_ERROR("Ipc", "SharedFrameWriter::Open", "IPC",
-                      "OpenFileMapping failed: {}", GetLastError());
+            LOG_ERROR("Common", __func__, "IPC", "OpenFileMapping failed: {}",  GetLastError());
             return false;
         }
     }
@@ -31,21 +30,18 @@ bool SharedFrameWriter::Open(const wchar_t* name) {
         MapViewOfFile(m_mapHandle, FILE_MAP_WRITE, 0, 0,
                       sizeof(SharedFrameData)));
     if (!m_data) {
-        LOG_ERROR("Ipc", "SharedFrameWriter::Open", "IPC",
-                  "MapViewOfFile failed: {}", GetLastError());
+        LOG_ERROR("Common", __func__, "IPC", "MapViewOfFile failed: {}",  GetLastError());
         CloseHandle(m_mapHandle);
         m_mapHandle = nullptr;
         return false;
     }
-    LOG_INFO("Ipc", "SharedFrameWriter::Open", "IPC",
-             "Shared memory opened for writing.");
+    LOG_INFO("Common", __func__, "IPC", "Shared memory opened for writing.");
 
     // Open frame-ready event (optional)
     m_frameEvent = OpenEventW(EVENT_MODIFY_STATE | SYNCHRONIZE, FALSE,
                               kFrameReadyEventName);
     if (!m_frameEvent) {
-        LOG_WARN("Ipc", "SharedFrameWriter::Open", "IPC",
-                 "OpenEvent failed for FrameReadyEvent: {}", GetLastError());
+        LOG_WARN("Common", __func__, "IPC", "OpenEvent failed for FrameReadyEvent: {}",  GetLastError());
     }
     return true;
 }
@@ -63,30 +59,25 @@ bool SharedFrameWriter::Create(const wchar_t* name) {
         INVALID_HANDLE_VALUE, &sa, PAGE_READWRITE,
         0, sizeof(SharedFrameData), name);
     if (!m_mapHandle) {
-        LOG_ERROR("Ipc", "SharedFrameWriter::Create", "IPC",
-                  "CreateFileMapping failed: {}", GetLastError());
+        LOG_ERROR("Common", __func__, "IPC", "CreateFileMapping failed: {}",  GetLastError());
         return false;
     }
     m_data = static_cast<SharedFrameData*>(
         MapViewOfFile(m_mapHandle, FILE_MAP_WRITE, 0, 0,
                       sizeof(SharedFrameData)));
     if (!m_data) {
-        LOG_ERROR("Ipc", "SharedFrameWriter::Create", "IPC",
-                  "MapViewOfFile failed: {}", GetLastError());
+        LOG_ERROR("Common", __func__, "IPC", "MapViewOfFile failed: {}",  GetLastError());
         CloseHandle(m_mapHandle);
         m_mapHandle = nullptr;
         return false;
     }
     std::memset(m_data, 0, sizeof(SharedFrameData));
-    LOG_INFO("Ipc", "SharedFrameWriter::Create", "IPC",
-             "Shared memory created for writing ({} bytes).",
-             sizeof(SharedFrameData));
+    LOG_INFO("Common", __func__, "IPC", "Shared memory created for writing ({} bytes).",  sizeof(SharedFrameData));
 
     // Create frame-ready event (auto-reset)
     m_frameEvent = CreateEventW(&sa, FALSE, FALSE, kFrameReadyEventName);
     if (!m_frameEvent) {
-        LOG_WARN("Ipc", "SharedFrameWriter::Create", "IPC",
-                 "CreateEvent failed for FrameReadyEvent: {}", GetLastError());
+        LOG_WARN("Common", __func__, "IPC", "CreateEvent failed for FrameReadyEvent: {}",  GetLastError());
     }
     return true;
 }
@@ -260,30 +251,26 @@ bool SharedFrameReader::Create(const wchar_t* name) {
         INVALID_HANDLE_VALUE, &sa, PAGE_READWRITE,
         0, sizeof(SharedFrameData), name);
     if (!m_mapHandle) {
-        LOG_ERROR("Ipc", "SharedFrameReader::Create", "IPC",
-                  "CreateFileMapping failed: {}", GetLastError());
+        LOG_ERROR("Common", __func__, "IPC", "CreateFileMapping failed: {}",  GetLastError());
         return false;
     }
     m_data = static_cast<SharedFrameData*>(
         MapViewOfFile(m_mapHandle, FILE_MAP_ALL_ACCESS, 0, 0,
                       sizeof(SharedFrameData)));
     if (!m_data) {
-        LOG_ERROR("Ipc", "SharedFrameReader::Create", "IPC",
-                  "MapViewOfFile failed: {}", GetLastError());
+        LOG_ERROR("Common", __func__, "IPC", "MapViewOfFile failed: {}",  GetLastError());
         CloseHandle(m_mapHandle);
         m_mapHandle = nullptr;
         return false;
     }
     // Zero-initialize
     std::memset(m_data, 0, sizeof(SharedFrameData));
-    LOG_INFO("Ipc", "SharedFrameReader::Create", "IPC",
-             "Shared memory created ({} bytes).", sizeof(SharedFrameData));
+    LOG_INFO("Common", __func__, "IPC", "Shared memory created ({} bytes).",  sizeof(SharedFrameData));
 
     // Create frame-ready event (auto-reset)
     m_frameEvent = CreateEventW(&sa, FALSE, FALSE, kFrameReadyEventName);
     if (!m_frameEvent) {
-        LOG_WARN("Ipc", "SharedFrameReader::Create", "IPC",
-                 "CreateEvent failed for FrameReadyEvent: {}", GetLastError());
+        LOG_WARN("Common", __func__, "IPC", "CreateEvent failed for FrameReadyEvent: {}",  GetLastError());
     }
     return true;
 }
@@ -291,29 +278,25 @@ bool SharedFrameReader::Create(const wchar_t* name) {
 bool SharedFrameReader::Open(const wchar_t* name) {
     m_mapHandle = OpenFileMappingW(FILE_MAP_READ, FALSE, name);
     if (!m_mapHandle) {
-        LOG_ERROR("Ipc", "SharedFrameReader::Open", "IPC",
-                  "OpenFileMapping failed: {}", GetLastError());
+        LOG_ERROR("Common", __func__, "IPC", "OpenFileMapping failed: {}",  GetLastError());
         return false;
     }
     m_data = static_cast<SharedFrameData*>(
         MapViewOfFile(m_mapHandle, FILE_MAP_READ, 0, 0,
                       sizeof(SharedFrameData)));
     if (!m_data) {
-        LOG_ERROR("Ipc", "SharedFrameReader::Open", "IPC",
-                  "MapViewOfFile failed: {}", GetLastError());
+        LOG_ERROR("Common", __func__, "IPC", "MapViewOfFile failed: {}",  GetLastError());
         CloseHandle(m_mapHandle);
         m_mapHandle = nullptr;
         return false;
     }
     m_lastReadId = 0;
-    LOG_INFO("Ipc", "SharedFrameReader::Open", "IPC",
-             "Shared memory opened for reading.");
+    LOG_INFO("Common", __func__, "IPC", "Shared memory opened for reading.");
 
     // Open frame-ready event
     m_frameEvent = OpenEventW(SYNCHRONIZE, FALSE, kFrameReadyEventName);
     if (!m_frameEvent) {
-        LOG_WARN("Ipc", "SharedFrameReader::Open", "IPC",
-                 "OpenEvent failed for FrameReadyEvent: {}", GetLastError());
+        LOG_WARN("Common", __func__, "IPC", "OpenEvent failed for FrameReadyEvent: {}",  GetLastError());
     }
     return true;
 }

--- a/EGoTouchService/Device/himax/HimaxAfe.cpp
+++ b/EGoTouchService/Device/himax/HimaxAfe.cpp
@@ -41,11 +41,7 @@ namespace Himax {
 // ── AFE 命令分发器 ──────────────────────────────────────────────────────────
 
 ChipResult<> AfeController::SendCommand(command cmd) {
-    LOG_INFO("Device", "AfeController::SendCommand", m_chip.GetStateStr(),
-             "Dispatch cmd={}({}), param={}",
-             AfeCommandToString(cmd.type),
-             static_cast<int>(cmd.type),
-             static_cast<unsigned int>(cmd.param));
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Dispatch cmd={}({}), param={}", AfeCommandToString(cmd.type), static_cast<int>(cmd.type), static_cast<unsigned int>(cmd.param));
 
     switch (cmd.type) {
     case AFE_Command::ClearStatus:       return ClearStatus(cmd.param);
@@ -70,20 +66,17 @@ ChipResult<> AfeController::EnterIdle(uint8_t param) {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("Device", "AfeController::EnterIdle", m_chip.GetStateStr(),
-             "Entering with param={}", static_cast<unsigned>(param));
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Entering with param={}", static_cast<unsigned>(param));
 
     if (auto res = HimaxProtocol::send_command(m_chip.GetMasterDevice(), 0x0a, param, m_chip.GetCurrentSlot()); !res) {
-        LOG_ERROR("Device", "AfeController::EnterIdle", m_chip.GetStateStr(),
-                  "Send ENTER_IDLE command failed!");
+        LOG_ERROR("HimaxAFE", __func__, m_chip.GetStateStr(), "Send ENTER_IDLE command failed!");
         return res;
     }
 
     if (auto res = m_chip.SetFrameReadIdlePolicy(); !res) return res;
     m_chip.SetAfeMode(THP_AFE_MODE::Idle);
 
-    LOG_INFO("Device", "AfeController::EnterIdle", m_chip.GetStateStr(),
-             "===== IDLE ENTER ===== No input detected, entering low-power idle.");
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "===== IDLE ENTER ===== No input detected, entering low-power idle.");
     return {};
 }
 
@@ -91,9 +84,9 @@ ChipResult<> AfeController::ForceExitIdle() {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("Device", "AfeController::ForceExitIdle", m_chip.GetStateStr(), "Entering!");
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Entering!");
     auto res = m_chip.NotifyTouchWakeup();
-    LOG_INFO("Device", "AfeController::ForceExitIdle", m_chip.GetStateStr(), "Out!");
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Out!");
     return res;
 }
 
@@ -101,16 +94,14 @@ ChipResult<> AfeController::StartCalibration(uint8_t param) {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("Device", "AfeController::StartCalibration", m_chip.GetStateStr(),
-             "Entering with param={}", static_cast<unsigned>(param));
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Entering with param={}", static_cast<unsigned>(param));
 
     if (auto res = HimaxProtocol::send_command(m_chip.GetMasterDevice(), 0x01, param, m_chip.GetCurrentSlot()); !res) {
-        LOG_ERROR("Device", "AfeController::StartCalibration", m_chip.GetStateStr(),
-                  "Send AFE_START_CALBRATION command failed!");
+        LOG_ERROR("HimaxAFE", __func__, m_chip.GetStateStr(), "Send AFE_START_CALBRATION command failed!");
         return res;
     }
 
-    LOG_INFO("Device", "AfeController::StartCalibration", m_chip.GetStateStr(), "Out!");
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Out!");
     return {};
 }
 
@@ -118,7 +109,7 @@ ChipResult<> AfeController::EnableFreqShift() {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("Device", "AfeController::EnableFreqShift", m_chip.GetStateStr(), "Entering!");
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Entering!");
     return HimaxProtocol::send_command(m_chip.GetMasterDevice(), 0x0d, 0x00, m_chip.GetCurrentSlot());
 }
 
@@ -127,12 +118,11 @@ ChipResult<> AfeController::DisableFreqShift() {
         return std::unexpected(ChipError::InvalidOperation);
 
     if (m_stylus.switchPolicy == 2) {
-        LOG_INFO("Device", "AfeController::DisableFreqShift", m_chip.GetStateStr(),
-                 "AUTO mode (switchPolicy=2), skipping disable command.");
+        LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "AUTO mode (switchPolicy=2), skipping disable command.");
         return {};
     }
 
-    LOG_INFO("Device", "AfeController::DisableFreqShift", m_chip.GetStateStr(), "Entering!");
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Entering!");
     return HimaxProtocol::send_command(m_chip.GetMasterDevice(), 0x02, 0x00, m_chip.GetCurrentSlot());
 }
 
@@ -142,12 +132,10 @@ ChipResult<> AfeController::ClearStatus(uint8_t cmd_val) {
 
     if (cmd_val & 0x40) {
         m_stylus.switchReqPending = false;
-        LOG_INFO("Device", "AfeController::ClearStatus", m_chip.GetStateStr(),
-                 "Cleared switchReqPending (0x40).");
+        LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Cleared switchReqPending (0x40).");
     }
     if (cmd_val & 0x20) {
-        LOG_INFO("Device", "AfeController::ClearStatus", m_chip.GetStateStr(),
-                 "Cleared FreqSwitchForceFlag (0x20).");
+        LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Cleared FreqSwitchForceFlag (0x20).");
     }
     return {};
 }
@@ -156,8 +144,7 @@ ChipResult<> AfeController::ForceToFreqPoint(uint8_t freq_idx) {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("Device", "AfeController::ForceToFreqPoint", m_chip.GetStateStr(),
-             "Entering with freq_idx={}", static_cast<unsigned>(freq_idx));
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Entering with freq_idx={}", static_cast<unsigned>(freq_idx));
     return HimaxProtocol::send_command(m_chip.GetMasterDevice(), 0x0c, freq_idx, m_chip.GetCurrentSlot());
 }
 
@@ -165,8 +152,7 @@ ChipResult<> AfeController::ForceToScanRate(uint8_t rate_idx) {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("Device", "AfeController::ForceToScanRate", m_chip.GetStateStr(),
-             "Entering with rate_idx={}", static_cast<unsigned>(rate_idx));
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Entering with rate_idx={}", static_cast<unsigned>(rate_idx));
     return HimaxProtocol::send_command(m_chip.GetMasterDevice(), 0x0e, rate_idx, m_chip.GetCurrentSlot());
 }
 
@@ -176,8 +162,7 @@ ChipResult<> AfeController::InitStylus(uint8_t pen_id) {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("Device", "AfeController::InitStylus", m_chip.GetStateStr(),
-             "0x71 connect → EnableFreqShift + set_stylus_connect(1)");
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "0x71 connect → EnableFreqShift + set_stylus_connect(1)");
 
     if (auto r = EnableFreqShift(); !r) return r;
 
@@ -187,8 +172,7 @@ ChipResult<> AfeController::InitStylus(uint8_t pen_id) {
     m_stylus.switchTargetIdx = 0;
     m_stylus.switchReqPending = false;
 
-    LOG_INFO("Device", "AfeController::InitStylus", m_chip.GetStateStr(),
-             "Stylus connected, waiting for PenTypeInfo (0x73) to bind freq pair.");
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Stylus connected, waiting for PenTypeInfo (0x73) to bind freq pair.");
     return {};
 }
 
@@ -196,9 +180,7 @@ ChipResult<> AfeController::SetStylusId(uint8_t pen_id) {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("Device", "AfeController::SetStylusId", m_chip.GetStateStr(),
-             "0x73 pen_type={} → 查频率表绑定 FreqPair",
-             static_cast<unsigned>(pen_id));
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "0x73 pen_type={} → 查频率表绑定 FreqPair", static_cast<unsigned>(pen_id));
 
     StylusFreqPair pair{0x00A1, 0x0018};  // 默认值（ID=5）
     for (auto& e : kFreqTable) {
@@ -212,9 +194,7 @@ ChipResult<> AfeController::SetStylusId(uint8_t pen_id) {
     m_stylus.pen_id   = pen_id;
     m_stylus.freqPair = pair;
 
-    LOG_INFO("Device", "AfeController::SetStylusId", m_chip.GetStateStr(),
-             "Stylus freq pair bound: freq0=0x{:04X}, freq1=0x{:04X}",
-             pair.freq0_cmd, pair.freq1_cmd);
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Stylus freq pair bound: freq0=0x{:04X}, freq1=0x{:04X}", pair.freq0_cmd, pair.freq1_cmd);
     return {};
 }
 
@@ -222,14 +202,14 @@ ChipResult<> AfeController::DisconnectStylus() {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("Device", "AfeController::DisconnectStylus", m_chip.GetStateStr(),
-             "DisableFreqShift + reset StylusState");
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "DisableFreqShift + reset StylusState");
 
     if (m_stylus.switchPolicy != 2) {
-        (void)DisableFreqShift();
+        if (auto res = DisableFreqShift(); !res) {
+            LOG_WARN("HimaxAFE", __func__, m_chip.GetStateStr(), "DisableFreqShift failed on disconnect, ignoring.");
+        }
     } else {
-        LOG_INFO("Device", "AfeController::DisconnectStylus", m_chip.GetStateStr(),
-                 "AUTO mode (policy=2) → skipping disable_freq_shift.");
+        LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "AUTO mode (policy=2) → skipping disable_freq_shift.");
     }
 
     m_stylus = StylusState{};
@@ -278,13 +258,11 @@ bool AfeController::ProcessStylusStatus() {
         uint32_t btAge = m_stylus.frameCounter - m_stylus.btLastSeenFrame;
         if (btAge > kBtPressureTimeout && !m_stylus.btPressureCleared) {
             m_stylus.btPressureCleared = true;
-            LOG_WARN("Device", "AfeController::ProcessStylusStatus", m_chip.GetStateStr(),
-                     "BT MCU silent >1s → pressure data reset.");
+            LOG_WARN("HimaxAFE", __func__, m_chip.GetStateStr(), "BT MCU silent >1s → pressure data reset.");
         }
         if (btAge > kBtHibernateTimeout) {
             m_stylus.btActive = false;
-            LOG_WARN("Device", "AfeController::ProcessStylusStatus", m_chip.GetStateStr(),
-                     "BT MCU heartbeat timeout (60s) → marking inactive.");
+            LOG_WARN("HimaxAFE", __func__, m_chip.GetStateStr(), "BT MCU heartbeat timeout (60s) → marking inactive.");
         }
     }
 
@@ -295,18 +273,14 @@ bool AfeController::ProcessStylusStatus() {
         m_stylus.lastSwitchFrame = m_stylus.frameCounter;
         m_stylus.btMismatchActive = false;
 
-        LOG_INFO("Device", "AfeController::ProcessStylusStatus", m_chip.GetStateStr(),
-                 "FreqShift done → freqIdx={}, tpFreq=[{},{}], btFreq=[{},{}]",
-                 m_stylus.freqIdx, tpFreq1, tpFreq2,
-                 m_stylus.btFreq1, m_stylus.btFreq2);
+        LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "FreqShift done → freqIdx={}, tpFreq=[{},{}], btFreq=[{},{}]", m_stylus.freqIdx, tpFreq1, tpFreq2, m_stylus.btFreq1, m_stylus.btFreq2);
     }
 
     // Pending 超时自愈
     if (m_stylus.switchReqPending) {
         uint32_t pendingAge = m_stylus.frameCounter - m_stylus.switchReqFrame;
         if (pendingAge > kPendingTimeout) {
-            LOG_WARN("Device", "AfeController::ProcessStylusStatus", m_chip.GetStateStr(),
-                     "FreqShift pending timeout ({} frames) → force clear.", pendingAge);
+            LOG_WARN("HimaxAFE", __func__, m_chip.GetStateStr(), "FreqShift pending timeout ({} frames) → force clear.", pendingAge);
             m_stylus.switchReqPending = false;
             m_stylus.lastSwitchFrame = m_stylus.frameCounter;
         }
@@ -334,9 +308,7 @@ bool AfeController::ProcessStylusStatus() {
                     m_stylus.switchReqPending = true;
                     m_stylus.switchReqFrame   = m_stylus.frameCounter;
                     m_stylus.btMismatchActive = false;
-                    LOG_INFO("Device", "AfeController::ProcessStylusStatus", m_chip.GetStateStr(),
-                             "BT-TP mismatch >30ms: tp={} bt={} → ForceToFreqPoint({})",
-                             tpFreq1, m_stylus.btFreq1, targetIdx);
+                    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "BT-TP mismatch >30ms: tp={} bt={} → ForceToFreqPoint({})", tpFreq1, m_stylus.btFreq1, targetIdx);
                     return true;
                 }
             }
@@ -353,17 +325,13 @@ bool AfeController::ProcessStylusStatus() {
         m_stylus.switchTargetIdx  = 1;
         m_stylus.switchReqPending = true;
         m_stylus.switchReqFrame   = m_stylus.frameCounter;
-        LOG_INFO("Device", "AfeController::ProcessStylusStatus", m_chip.GetStateStr(),
-                 "F0({})−F1({})={} ≥{} → ForceToFreqPoint(1), tpFreq=[{},{}]",
-                 f0_noise, f1_noise, diff_01, kNoiseThresholdF0toF1, tpFreq1, tpFreq2);
+        LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "F0({})−F1({})={} ≥{} → ForceToFreqPoint(1), tpFreq=[{},{}]", f0_noise, f1_noise, diff_01, kNoiseThresholdF0toF1, tpFreq1, tpFreq2);
         return true;
     } else if (diff_10 > kNoiseThresholdF1toF0 && m_stylus.freqIdx != 0) {
         m_stylus.switchTargetIdx  = 0;
         m_stylus.switchReqPending = true;
         m_stylus.switchReqFrame   = m_stylus.frameCounter;
-        LOG_INFO("Device", "AfeController::ProcessStylusStatus", m_chip.GetStateStr(),
-                 "F1({})−F0({})={} >{} → ForceToFreqPoint(0), tpFreq=[{},{}]",
-                 f1_noise, f0_noise, diff_10, kNoiseThresholdF1toF0, tpFreq1, tpFreq2);
+        LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "F1({})−F0({})={} >{} → ForceToFreqPoint(0), tpFreq=[{},{}]", f1_noise, f0_noise, diff_10, kNoiseThresholdF1toF0, tpFreq1, tpFreq2);
         return true;
     }
     return false;
@@ -382,8 +350,7 @@ void AfeController::UpdateBtHeartbeat(uint8_t freq1, uint8_t freq2) {
     m_stylus.btPressureCleared = false;
 
     if (freqChanged) {
-        LOG_INFO("Device", "AfeController::UpdateBtHeartbeat", m_chip.GetStateStr(),
-                 "BT freq updated: [{}, {}]", freq1, freq2);
+        LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "BT freq updated: [{}, {}]", freq1, freq2);
     }
 }
 

--- a/EGoTouchService/Device/himax/HimaxChip.cpp
+++ b/EGoTouchService/Device/himax/HimaxChip.cpp
@@ -71,19 +71,17 @@ Chip::Chip(const std::wstring& master_path, const std::wstring& slave_path, cons
 ChipResult<> Chip::SetFrameReadPolicy(bool block, uint8_t timeoutMs) {
     auto apply_policy = [&](HalDevice* dev, const char* devName) -> ChipResult<> {
         if (!dev || !dev->IsValid()) {
-            LOG_ERROR("Device", "Chip::SetFrameReadPolicy", GetStateStr(), "{} handle invalid", devName);
+            LOG_ERROR("HimaxChip", __func__, GetStateStr(), "{} handle invalid",  devName);
             return std::unexpected(ChipError::CommunicationError);
         }
 
         if (auto res = dev->SetBlock(block); !res) {
-            LOG_ERROR("Device", "Chip::SetFrameReadPolicy", GetStateStr(),
-                      "{} SetBlock({}) failed", devName, block ? 1 : 0);
+            LOG_ERROR("HimaxChip", __func__, GetStateStr(), "{} SetBlock({}) failed",  devName, block ? 1 : 0);
             return res;
         }
 
         if (auto res = dev->SetTimeOut(timeoutMs); !res) {
-            LOG_ERROR("Device", "Chip::SetFrameReadPolicy", GetStateStr(),
-                      "{} SetTimeOut({}) failed", devName, timeoutMs);
+            LOG_ERROR("HimaxChip", __func__, GetStateStr(), "{} SetTimeOut({}) failed",  devName, timeoutMs);
             return res;
         }
         return {};
@@ -92,8 +90,7 @@ ChipResult<> Chip::SetFrameReadPolicy(bool block, uint8_t timeoutMs) {
     if (auto res = apply_policy(m_master.get(), "Master"); !res) return res;
     if (auto res = apply_policy(m_slave.get(), "Slave"); !res) return res;
 
-    LOG_INFO("Device", "Chip::SetFrameReadPolicy", GetStateStr(),
-             "Applied read policy: block={}, timeout={}ms", block ? 1 : 0, timeoutMs);
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Applied read policy: block={}, timeout={}ms",  block ? 1 : 0, timeoutMs);
     return {};
 }
 
@@ -118,8 +115,7 @@ ChipResult<> Chip::NotifyTouchWakeup() {
 
     if (auto res = SetFrameReadNormalPolicy(); !res) return res;
     afe_mode = THP_AFE_MODE::Normal;
-    LOG_INFO("Device", "Chip::NotifyTouchWakeup", GetStateStr(),
-             "===== IDLE EXIT ===== Touch wakeup → Normal mode.");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "===== IDLE EXIT ===== Touch wakeup → Normal mode.");
     return {};
 }
 
@@ -168,17 +164,17 @@ ChipResult<> Chip::check_bus(void) {
 
     // Check Slave
     if (auto res = m_slave->ReadBus(0x13, tmp_data, 1); !res) {
-        LOG_ERROR("Device", "Chip::check_bus", GetStateStr(), "Slave Bus Dead! Error: {:d}", (int)res.error());
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Slave Bus Dead! Error: {:d}",  (int)res.error());
         return std::unexpected(ChipError::CommunicationError);
     }
-    LOG_INFO("Device", "Chip::check_bus", GetStateStr(), "Slave Bus Alive! (0x13: 0x{:02X})", tmp_data[0]);
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Slave Bus Alive! (0x13: 0x{:02X})",  tmp_data[0]);
 
     // Check Master
     if (auto res = m_master->ReadBus(0x13, tmp_data1, 1); !res) {
-        LOG_ERROR("Device", "Chip::check_bus", GetStateStr(), "Master Bus Dead! Error: {:d}", (int)res.error());
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Master Bus Dead! Error: {:d}",  (int)res.error());
         return std::unexpected(ChipError::CommunicationError);
     }
-    LOG_INFO("Device", "Chip::check_bus", GetStateStr(), "Master Bus Alive! (0x13: 0x{:02X})", tmp_data1[0]);
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Master Bus Alive! (0x13: 0x{:02X})",  tmp_data1[0]);
 
     return {};
 }
@@ -210,7 +206,7 @@ ChipResult<> Chip::himax_mcu_assign_sorting_mode(uint8_t* tmp_data) {
         }
     }
     if (!step_ok) {
-        LOG_ERROR("Device", "Chip::himax_mcu_assign_sorting_mode", GetStateStr(), "Failed to assign sorting mode!");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Failed to assign sorting mode!");
         return std::unexpected(ChipError::VerificationFailed);
     }
     return {};
@@ -223,7 +219,7 @@ ChipResult<> Chip::himax_switch_data_type(DeviceType device, THP_INSPECTION_ENUM
     uint8_t cnt = 50;
 
     if (!dev_res) {
-        LOG_ERROR("Device", "Chip::himax_switch_data_type", GetStateStr(), "get device failed");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "get device failed");
         return std::unexpected(dev_res.error());
     }
     HalDevice* dev = *dev_res;
@@ -259,7 +255,7 @@ ChipResult<> Chip::himax_switch_data_type(DeviceType device, THP_INSPECTION_ENUM
         message = "HX_BACK_NORMAL_UNKNOW";
         break;
     }
-    LOG_INFO("Device", "Chip::himax_switch_data_type", GetStateStr(), "switch to {}!", message);
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "switch to {}!",  message);
 
     ChipResult<> step_ok = std::unexpected(ChipError::InternalError);
     do {
@@ -267,10 +263,10 @@ ChipResult<> Chip::himax_switch_data_type(DeviceType device, THP_INSPECTION_ENUM
     }while (!step_ok && --cnt > 0);
 
     if (step_ok) {
-        LOG_INFO("Device", "Chip::himax_switch_data_type", GetStateStr(), "switch to {} success!", message);
+        LOG_INFO("HimaxChip", __func__, GetStateStr(), "switch to {} success!",  message);
         return {};
     } else {
-        LOG_ERROR("Device", "Chip::himax_switch_data_type", GetStateStr(), "switch failed!");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "switch failed!");
         return step_ok;
     }
 }
@@ -287,28 +283,28 @@ ChipResult<> Chip::hx_hw_reset_ahb_intf(DeviceType type) {
 
     uint8_t tmp_data[4];
     
-    LOG_INFO("Device", "Chip::hx_hw_reset_ahb_intf", GetStateStr(), "Enter!");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Enter!");
 
     himax_parse_assign_cmd(pfw_op.data_clear, tmp_data, 4);
     if (auto res = HimaxProtocol::register_write(dev, pdriver_op.addr_fw_define_2nd_flash_reload, tmp_data, 4); !res) {
-        LOG_ERROR("Device", "Chip::hx_hw_reset_ahb_intf", GetStateStr(), "clear reload failed");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "clear reload failed");
         return res;
     }
 
     // 物理复位操作：经测试，Slave 句柄 (WinError 1168) 不支持复位控制，
     // 物理复位引脚仅绑定在 Master 句柄上，故统一由 m_master 执行。
     if (auto res = m_master->SetReset(0); !res) {
-        LOG_ERROR("Device", "Chip::hx_hw_reset_ahb_intf", GetStateStr(), "Physical SetReset(0) via Master failed, WinError: {}", (int)m_master->GetError());
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Physical SetReset(0) via Master failed, WinError: {}",  (int)m_master->GetError());
         return res;
     }
 
     if (auto res = m_master->SetReset(1); !res) {
-        LOG_ERROR("Device", "Chip::hx_hw_reset_ahb_intf", GetStateStr(), "Physical SetReset(1) via Master failed, WinError: {}", (int)m_master->GetError());
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Physical SetReset(1) via Master failed, WinError: {}",  (int)m_master->GetError());
         return res;
     }
 
     if (auto res = HimaxProtocol::burst_enable(dev, 1); !res) {
-        LOG_ERROR("Device", "Chip::hx_hw_reset_ahb_intf", GetStateStr(), "burst_enable set to 1 failed");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "burst_enable set to 1 failed");
         return res;
     }
 
@@ -338,20 +334,20 @@ ChipResult<> Chip::hx_sw_reset_ahb_intf(DeviceType type) {
     }
 
     if (!safe_mode_ok) {
-        LOG_WARN("Device", "Chip::hx_sw_reset_ahb_intf", GetStateStr(), "Failed to enter Safe Mode before reset, proceeding anyway...");
+        LOG_WARN("HimaxChip", __func__, GetStateStr(), "Failed to enter Safe Mode before reset, proceeding anyway...");
     }
 
     Sleep(10);
     himax_parse_assign_cmd(pdriver_op.data_fw_define_flash_reload_en, tmp_data, 4);
     if (auto res = HimaxProtocol::register_write(dev, pdriver_op.addr_fw_define_2nd_flash_reload, tmp_data, 4); !res) {
-        LOG_ERROR("Device", "Chip::hx_sw_reset_ahb_intf", GetStateStr(), "clean reload done failed!");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "clean reload done failed!");
         return res;
     }
     Sleep(10);
     
     himax_parse_assign_cmd(pfw_op.data_system_reset, tmp_data, 4);
     if (auto res = HimaxProtocol::register_write(dev, pfw_op.addr_system_reset, tmp_data, 4); !res) {
-        LOG_ERROR("Device", "Chip::hx_sw_reset_ahb_intf", GetStateStr(), "Failed to write System Reset command");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Failed to write System Reset command");
         return res;
     }
 
@@ -367,7 +363,7 @@ ChipResult<> Chip::hx_sw_reset_ahb_intf(DeviceType type) {
  * @return bool 是否成功
  */
 ChipResult<> Chip::himax_mcu_reload_disable(uint8_t disable) {
-    LOG_INFO("Device", "Chip::himax_mcu_reload_disable", GetStateStr(), "entering!");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "entering!");
     std::array<uint8_t, 4> tmp_data{};
 
     if (disable) {
@@ -380,7 +376,7 @@ ChipResult<> Chip::himax_mcu_reload_disable(uint8_t disable) {
         return res;
     }
 
-    LOG_INFO("Device", "Chip::himax_mcu_reload_disable", GetStateStr(), "setting OK!");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "setting OK!");
     return {};
 }
 
@@ -391,7 +387,7 @@ ChipResult<> Chip::himax_mcu_reload_disable(uint8_t disable) {
  */
 ChipResult<> Chip::hx_set_N_frame(uint8_t nFrame) {
     if (!m_master || !m_master->IsValid()) return std::unexpected(ChipError::CommunicationError);
-    LOG_INFO("Device", "Chip::hx_set_N_frame", GetStateStr(), "Enter!");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Enter!");
 
     std::array<uint8_t, 4> tmp_data{};
 
@@ -411,7 +407,7 @@ ChipResult<> Chip::hx_set_N_frame(uint8_t nFrame) {
     pack32(target2);
     if (auto res = HimaxProtocol::write_and_verify(m_master.get(), pfw_op.addr_set_frame_addr, tmp_data.data(), 4); !res) return res;
     
-    LOG_INFO("Device", "Chip::hx_set_N_frame", GetStateStr(), "Out!");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Out!");
     return {};
 }
 
@@ -420,7 +416,7 @@ ChipResult<> Chip::himax_switch_mode_inspection(THP_INSPECTION_ENUM mode) {
     constexpr int kUnlockAttempts = 20;
     std::array<uint8_t, 4> tmp_data{};
     bool clear = false;
-    LOG_INFO("Device", "Chip::himax_switch_mode_inspection", GetStateStr(), "Entering!");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Entering!");
 
     /*Stop Handshakng*/
     himax_parse_assign_cmd(psram_op.addr_rawdata_end, tmp_data.data(), 4);
@@ -431,7 +427,7 @@ ChipResult<> Chip::himax_switch_mode_inspection(THP_INSPECTION_ENUM mode) {
         }
     }
     if (!clear) {
-        LOG_ERROR("Device", "Chip::himax_switch_mode_inspection", GetStateStr(), "switch mode unlock failed after {} attempts", kUnlockAttempts);
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "switch mode unlock failed after {} attempts",  kUnlockAttempts);
         return std::unexpected(ChipError::VerificationFailed);
     }
 
@@ -466,11 +462,11 @@ ChipResult<> Chip::himax_switch_mode_inspection(THP_INSPECTION_ENUM mode) {
     }
 
     if (auto res = himax_mcu_assign_sorting_mode(tmp_data.data()); !res) {
-        LOG_ERROR("Device", "Chip::himax_switch_mode_inspection", GetStateStr(), "Failed to switch to {}", message);
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Failed to switch to {}",  message);
         return res;
     }
     
-    LOG_INFO("Device", "Chip::himax_switch_mode_inspection", GetStateStr(), "Switching to {} Success", message);
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Switching to {} Success",  message);
     return {};
 }
 
@@ -495,20 +491,20 @@ ChipResult<> Chip::himax_mcu_read_FW_status(void) {
 
     for (uint32_t addr : dbg_reg_ary) {
         if (auto res = HimaxProtocol::register_read(m_master.get(), addr, tmp_data.data(), 4); !res) return res;
-        LOG_INFO("Device", "Chip::himax_mcu_read_FW_status", GetStateStr(), "{:x} = {::#x}",addr, tmp_data);
+        // LOG_TRACE("HimaxChip", __func__, GetStateStr(), "{:x} = {::#x}",  ddr, tmp_data);
     }
     return {};
 }
 
 ChipResult<> Chip::himax_mcu_interface_on(void) {
-    LOG_INFO("Device", "Chip::himax_mcu_interface_on", GetStateStr(), "Enter!");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Enter!");
 
     std::array<uint8_t, 4> tmp_data{};
     std::array<uint8_t, 4> tmp_data2{};
     int cnt = 0;
     
     if (auto res = m_master->ReadBus(pic_op.addr_ahb_rdata_byte_0, tmp_data.data(), 4); !res) {
-        LOG_ERROR("Device", "Chip::himax_mcu_interface_on", GetStateStr(), "ReadBus failed");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "ReadBus failed");
         return res;
     }        
     
@@ -516,13 +512,13 @@ ChipResult<> Chip::himax_mcu_interface_on(void) {
         tmp_data[0] = pic_op.data_conti;
         
         if (auto res = m_master->WriteBus(pic_op.addr_conti, NULL, tmp_data.data(), 1); !res) {
-            LOG_ERROR("Device", "Chip::himax_mcu_interface_on", GetStateStr(), "bus access fail!");
+            LOG_ERROR("HimaxChip", __func__, GetStateStr(), "bus access fail!");
             return res;
         }
         
         tmp_data[0] = pic_op.data_incr4;
         if (auto res = m_master->WriteBus(pic_op.addr_incr4, NULL, tmp_data.data(), 1); !res) {
-            LOG_ERROR("Device", "Chip::himax_mcu_interface_on", GetStateStr(), "bus access fail!");
+            LOG_ERROR("HimaxChip", __func__, GetStateStr(), "bus access fail!");
             return res;
         }
 
@@ -537,7 +533,7 @@ ChipResult<> Chip::himax_mcu_interface_on(void) {
     } while (++cnt < 10);
 
     if (cnt > 0) {
-        LOG_INFO("Device", "Chip::himax_mcu_interface_on", GetStateStr(), "Polling burst mode: {:d} times", cnt);
+        LOG_INFO("HimaxChip", __func__, GetStateStr(), "Polling burst mode: {:d} times",  cnt);
     }
     return {};
 }
@@ -548,7 +544,7 @@ ChipResult<> Chip::himax_mcu_interface_on(void) {
  * @return bool 是否成功
  */
 ChipResult<> Chip::hx_sense_on(bool FlashMode) {
-    LOG_INFO("Device", "Chip::hx_sense_on", GetStateStr(), "Enter, isHwReset = {}", FlashMode);
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Enter, isHwReset = {}",  FlashMode);
     std::array<uint8_t, 4> tmp_data{};
 
     if (auto res = himax_mcu_interface_on(); !res) return res;
@@ -590,7 +586,7 @@ ChipResult<> Chip::hx_sense_off(bool check_en) {
         if (!step_ok) return step_ok;
 
         if ((back_data[0] != 0x05) || (check_en == false)) { 
-            LOG_INFO("Device", "Chip::hx_sense_off", GetStateStr(), "Do not need wait FW, status = 0x{:X}", back_data[0]);
+            LOG_INFO("HimaxChip", __func__, GetStateStr(), "Do not need wait FW, status = 0x{:X}",  back_data[0]);
             break;
         }
 
@@ -609,7 +605,7 @@ ChipResult<> Chip::hx_sense_off(bool check_en) {
         }
 
         if (auto res = HimaxProtocol::register_read(m_master.get(), pfw_op.addr_chk_fw_status, back_data.data(), 4); !res) return res;
-        LOG_INFO("Device", "Chip::hx_sense_off", GetStateStr(), "Check enter_safe_mode data[0]={:x}", back_data[0]);
+        LOG_INFO("HimaxChip", __func__, GetStateStr(), "Check enter_safe_mode data[0]={:x}",  back_data[0]);
 
         if (back_data[0] == 0x0C) {
             //reset TCON
@@ -624,12 +620,12 @@ ChipResult<> Chip::hx_sense_off(bool check_en) {
         Sleep(50);
     }while (cnt++ < 15);
 
-    LOG_INFO("Device", "Chip::hx_sense_off", GetStateStr(), "Out!");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Out!");
     return std::unexpected(ChipError::VerificationFailed);
 }
 
 ChipResult<> Chip::himax_mcu_power_on_init(void) {
-    LOG_INFO("Device", "Chip::himax_mcu_power_on_init", GetStateStr(), "entering!");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "entering!");
     std::array<uint8_t, 4> tmp_data{0x01, 0x00, 0x00, 0x00};
     std::array<uint8_t, 4> tmp_data2{};
     uint8_t retry = 0;
@@ -641,20 +637,20 @@ ChipResult<> Chip::himax_mcu_power_on_init(void) {
 
     if (auto res = hx_sense_on(false); !res) return res;
 
-    LOG_INFO("Device", "Chip::himax_mcu_power_on_init", GetStateStr(), "waiting for FW reload data");
+    // LOG_TRACE("HimaxChip", __func__, GetStateStr(), "waiting for FW reload data");
 
     while (retry++ < 30) {
         if (auto res = HimaxProtocol::register_read(m_master.get(), pdriver_op.addr_fw_define_2nd_flash_reload, tmp_data.data(), 4); !res) return res;
         if ((tmp_data[3] == 0x00 && tmp_data[2] == 0x00 &&
 			tmp_data[1] == 0x72 && tmp_data[0] == 0xC0)) {
-            LOG_INFO("Device", "Chip::himax_mcu_power_on_init", GetStateStr(), "FW reload done!");
+            LOG_INFO("HimaxChip", __func__, GetStateStr(), "FW reload done!");
             return {};
         }
-        LOG_INFO("Device", "Chip::himax_mcu_power_on_init", GetStateStr(), "waiting for FW reload data %d", retry); 
+        // LOG_TRACE("HimaxChip", __func__, GetStateStr(), "waiting for FW reload data %d",  retry); 
         auto res = himax_mcu_read_FW_status(); // 打印 log
         Sleep(11);
     }
-    LOG_ERROR("Device", "Chip::himax_mcu_power_on_init", GetStateStr(), "FW reload timeout!");
+    LOG_ERROR("HimaxChip", __func__, GetStateStr(), "FW reload timeout!");
     return std::unexpected(ChipError::Timeout);
 }
 
@@ -668,7 +664,7 @@ ChipResult<> Chip::himax_mcu_power_on_init(void) {
 ChipResult<> Chip::Init(void) {
     if (auto res = hx_hw_reset_ahb_intf(DeviceType::Master); !res) return res;
     Sleep(10);
-    LOG_INFO("Device", "Chip::Init", GetStateStr(), "Starting initialization sequence...");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Starting initialization sequence...");
 
     std::array<uint8_t, 4> tmp_data = {0xA5, 0x5A, 0x00, 0x00};
 
@@ -685,17 +681,17 @@ ChipResult<> Chip::Init(void) {
     
     // 打开中断/数据采集通道
     if (auto res = m_master->IntOpen(); !res) {
-        LOG_ERROR("Device", "Chip::Init", GetStateStr(), "Master IntOpen failed!");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Master IntOpen failed!");
         return res;
     }
     if (auto res = m_slave->IntOpen(); !res) {
-        LOG_ERROR("Device", "Chip::Init", GetStateStr(), "Slave IntOpen failed!");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Slave IntOpen failed!");
         return res;
     }
 
     // Default to normal read policy after channel is opened.
     if (auto res = SetFrameReadNormalPolicy(); !res) {
-        LOG_ERROR("Device", "Chip::Init", GetStateStr(), "Apply normal read policy failed");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Apply normal read policy failed");
         return res;
     }
 
@@ -706,22 +702,20 @@ ChipResult<> Chip::Init(void) {
     m_afe.ResetStylusState();
 
     if (auto res = m_afe.StartCalibration(); !res) {
-        LOG_WARN("Device", "Chip::Init", GetStateStr(),
-                 "start_calibration failed (non-fatal), chip may use default rate");
+        LOG_WARN("HimaxChip", __func__, GetStateStr(), "start_calibration failed (non-fatal), chip may use default rate");
     } else {
-        LOG_INFO("Device", "Chip::Init", GetStateStr(), "start_calibration success.");
+        LOG_INFO("HimaxChip", __func__, GetStateStr(), "start_calibration success.");
     }
     
     // 强制芯片切换到 120Hz 扫描率（cmd=0x0E, val=0x00）
     // 确保上电后不处于芯片默认的低帧率或未知模式
     if (auto res = m_afe.ForceToScanRate(0x00); !res) {
-        LOG_WARN("Device", "Chip::Init", GetStateStr(),
-                 "force_to_scan_rate(120Hz) failed (non-fatal), chip may use default rate");
+        LOG_WARN("HimaxChip", __func__, GetStateStr(), "force_to_scan_rate(120Hz) failed (non-fatal), chip may use default rate");
     } else {
-        LOG_INFO("Device", "Chip::Init", GetStateStr(), "Scan rate forced to 120Hz.");
+        LOG_INFO("HimaxChip", __func__, GetStateStr(), "Scan rate forced to 120Hz.");
     }
 
-    LOG_INFO("Device", "Chip::Init", GetStateStr(), "Initialization and Sense ON successful.");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Initialization and Sense ON successful.");
     return {};
 }
 
@@ -730,22 +724,22 @@ ChipResult<> Chip::Deinit(bool check_en) {
     // immediately stop accessing the device.  Their GetConnectionState() checks will
     // fail before we tear down the channels below.
     m_connState.store(ConnectionState::Unconnected);
-    LOG_INFO("Device", "Chip::Deinit", GetStateStr(), "Starting Deinit sequence...");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Starting Deinit sequence...");
 
     // Send sense off if bus is accessible
     auto resOff = hx_sense_off(check_en);
     if (!resOff) {
-        LOG_WARN("Device", "Chip::Deinit", GetStateStr(), "hx_sense_off had issues during Deinit.");
+        LOG_WARN("HimaxChip", __func__, GetStateStr(), "hx_sense_off had issues during Deinit.");
     }
     
     auto m_res = m_master->IntClose();
     auto s_res = m_slave->IntClose();
     
     if (!m_res || !s_res) {
-         LOG_WARN("Device", "Chip::Deinit", GetStateStr(), "IntClose had issues during Deinit.");
+         LOG_WARN("HimaxChip", __func__, GetStateStr(), "IntClose had issues during Deinit.");
     }
     
-    LOG_INFO("Device", "Chip::Deinit", GetStateStr(), "Deinit successful.");
+    LOG_INFO("HimaxChip", __func__, GetStateStr(), "Deinit successful.");
     return {};
 }
 
@@ -762,13 +756,12 @@ void Chip::HoldReset() {
     (void)m_master->IntClose();
     (void)m_slave->IntClose();
 
-    LOG_INFO("Device", "Chip::HoldReset", "Unconnected",
-             "Reset held low, interrupt channels closed (suspend).");
+    LOG_INFO("HimaxChip", __func__, "Unconnected", "Reset held low, interrupt channels closed (suspend).");
 }
 
 Chip::~Chip() {
     if (m_connState.load() != ConnectionState::Unconnected) {
-        LOG_INFO("Device", "Chip::~Chip", GetStateStr(), "Implicitly calling Deinit().");
+        LOG_INFO("HimaxChip", __func__, GetStateStr(), "Implicitly calling Deinit().");
         (void)Deinit(false);
     }
 }
@@ -834,8 +827,7 @@ ChipResult<> Chip::GetFrame(void) {
         if (m_res && s_res) {
             if (isFingerDetected() || isStylusDetected()) {
                 (void)NotifyTouchWakeup();
-                LOG_INFO("Device", "Chip::GetFrame", GetStateStr(),
-                         "Input detected in idle → wakeup to Normal");
+                LOG_INFO("HimaxChip", __func__, GetStateStr(), "Input detected in idle → wakeup to Normal");
             }
             // 无输入: 丢弃 idle 帧，返回超时让 caller 继续循环
             return std::unexpected(ChipError::Timeout);
@@ -864,7 +856,7 @@ ChipResult<> Chip::GetFrame(void) {
     if (auto res = m_slave->GetFrame(back_data.data() + 5063, 339, nullptr); !res) {
         if (m_slave->IsTimeoutError())
             return std::unexpected(ChipError::Timeout);
-        LOG_ERROR("Device", "Chip::GetFrame", GetStateStr(), "Slave GetFrame failed!");
+        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Slave GetFrame failed!");
         return res;
     }
 
@@ -874,7 +866,7 @@ ChipResult<> Chip::GetFrame(void) {
         if (auto res = m_master->GetFrame(back_data.data(), 5063, nullptr); !res) {
             if (m_master->IsTimeoutError())
                 return std::unexpected(ChipError::Timeout);
-            LOG_ERROR("Device", "Chip::GetFrame", GetStateStr(), "Master GetFrame failed!");
+            LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Master GetFrame failed!");
             return res;
         }
     }
@@ -886,12 +878,10 @@ ChipResult<> Chip::GetFrame(void) {
     bool stylusNow = isStylusDetected();
     if (stylusNow && !m_stylusActive) {
         m_stylusActive = true;
-        LOG_INFO("Device", "Chip::GetFrame", GetStateStr(),
-                 "Stylus detected in frame data → 2:1 interleave ON (slave 240Hz)");
+        LOG_INFO("HimaxChip", __func__, GetStateStr(), "Stylus detected in frame data → 2:1 interleave ON (slave 240Hz)");
     } else if (!stylusNow && m_stylusActive) {
         m_stylusActive = false;
-        LOG_INFO("Device", "Chip::GetFrame", GetStateStr(),
-                 "Stylus lost in frame data → 2:1 interleave OFF (slave 120Hz)");
+        LOG_INFO("HimaxChip", __func__, GetStateStr(), "Stylus lost in frame data → 2:1 interleave OFF (slave 120Hz)");
     }
 
     // ── 零帧计数 & idle 自动进入 ─────────────────────────────
@@ -902,9 +892,7 @@ ChipResult<> Chip::GetFrame(void) {
     } else {
         m_zeroFrameCount++;
         if (m_zeroFrameCount >= kIdleEntryThreshold) {
-            LOG_INFO("Device", "Chip::GetFrame", GetStateStr(),
-                     "No input for {} frames → EnterIdle",
-                     m_zeroFrameCount);
+            LOG_INFO("HimaxChip", __func__, GetStateStr(), "No input for {} frames → EnterIdle",  m_zeroFrameCount);
             m_stylusActive = false;  // idle 进入时强制关闭 2:1
             (void)m_afe.EnterIdle();
             m_zeroFrameCount = 0;
@@ -913,10 +901,7 @@ ChipResult<> Chip::GetFrame(void) {
 
     // 调试：每 600 帧打计数日志
     if ((m_frameCount % 600) == 0) {
-        LOG_DEBUG("Device", "Chip::GetFrame", GetStateStr(),
-                 "[IDLE-DIAG] m_frameCount={} m_zeroFrameCount={} afe_mode={}",
-                 m_frameCount, m_zeroFrameCount,
-                 afe_mode.load() == THP_AFE_MODE::Idle ? "Idle" : "Normal");
+        LOG_DEBUG("HimaxChip", __func__, GetStateStr(), "[IDLE-DIAG] m_frameCount={} m_zeroFrameCount={} afe_mode={}",  m_frameCount, m_zeroFrameCount, afe_mode.load() == THP_AFE_MODE::Idle ? "Idle" : "Normal");
     }
 
     return {};

--- a/EGoTouchService/Device/penevt/PenEventBridge.cpp
+++ b/EGoTouchService/Device/penevt/PenEventBridge.cpp
@@ -77,8 +77,7 @@ void PenEventBridge::SendAck(uint8_t ackCode) {
         0x01, 0x80, 0x11, 0x00, ackCode
     };
     SendRawPacket(pkt);
-    LOG_INFO("PenEventBridge", "SendAck", "MCU",
-             "ACK sent: 0x{:02X}", ackCode);
+    LOG_INFO("PenEvent", __func__, "MCU", "ACK sent: 0x{:02X}", ackCode);
 }
 
 void PenEventBridge::SendInitParamEcho(const uint8_t* data, size_t len) {
@@ -89,8 +88,7 @@ void PenEventBridge::SendInitParamEcho(const uint8_t* data, size_t len) {
     pkt[6] = 0x11; pkt[7] = 0x20;
     std::copy(data, data + payloadLen, pkt.begin() + 8);
     SendRawPacket(pkt);
-    LOG_INFO("PenEventBridge", "SendInitParamEcho", "MCU",
-             "0x7D01 InitParam echo sent ({} bytes payload).", payloadLen);
+    LOG_INFO("PenEvent", __func__, "MCU", "0x7D01 InitParam echo sent ({} bytes payload).", payloadLen);
 }
 
 // ── BtHidChannel hooks ────────────────────────────────────────────────────
@@ -121,7 +119,7 @@ void PenEventBridge::OnPacketReceived(const std::vector<uint8_t>& packet) {
             0x01, 0x2E, 0x11, 0x00
         };
         SendRawPacket(pkt2e01);
-        LOG_INFO("PenEventBridge", "OnPacketReceived", "MCU", "Sent 0x2E01 pairing confirmation.");
+        LOG_INFO("PenEvent", __func__, "MCU", "Sent 0x2E01 pairing confirmation.");
     }
 
     // 4. 触发上层回调
@@ -146,7 +144,7 @@ void PenEventBridge::OnPacketReceived(const std::vector<uint8_t>& packet) {
 // ── 握手 ──────────────────────────────────────────────────────────────────
 void PenEventBridge::RunHandshake() {
     if (!IsTransportOpen()) return;
-    LOG_INFO("PenEventBridge", "RunHandshake", "MCU", "Sending 0x7101 + 0x7701 handshake.");
+    LOG_INFO("PenEvent", __func__, "MCU", "Sending 0x7101 + 0x7701 handshake.");
 
     const std::vector<uint8_t> q1 = {0x07,0x00,0x02,0x00, 0x01,0x71, 0x11,0x00};
     SendRawPacket(q1);
@@ -156,7 +154,7 @@ void PenEventBridge::RunHandshake() {
     const std::vector<uint8_t> q2 = {0x07,0x00,0x02,0x00, 0x01,0x77, 0x11,0x00};
     SendRawPacket(q2);
 
-    LOG_INFO("PenEventBridge", "RunHandshake", "MCU", "Handshake complete.");
+    LOG_INFO("PenEvent", __func__, "MCU", "Handshake complete.");
 }
 
 } // namespace Himax::Pen

--- a/EGoTouchService/Device/runtime/DeviceRuntime.cpp
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.cpp
@@ -44,13 +44,12 @@ DeviceRuntime::~DeviceRuntime() { Stop(); }
 bool DeviceRuntime::Start() {
     if (m_running.exchange(true)) return false;
     m_stopReason.store(StopReason::None);  // ← critical: clear stop reason for restart
-    m_state.store(workerState::ready);
+    SetState(workerState::ready);
     m_needSuspendDeinit = false;
     m_recoverCount = 0;
     m_lastNote = "Runtime started";
     m_thread = std::thread(&DeviceRuntime::WorkerMain, this);
-    LOG_INFO("Device", "DeviceRuntime::Start", "ready",
-             "Worker thread launched.");
+    LOG_INFO("Runtime", __func__, "ready", "Worker thread launched.");
     return true;
 }
 
@@ -58,7 +57,7 @@ void DeviceRuntime::Stop() {
     m_stopReason.store(StopReason::Shutdown);
     if (m_thread.joinable()) m_thread.join();
     m_running.store(false);
-    m_state.store(workerState::quit);
+    SetState(workerState::quit);
     m_lastNote = "Runtime stopped";
 }
 
@@ -98,31 +97,25 @@ void DeviceRuntime::IngestSystemEvent(
     switch (ev.type) {
     case ET::DisplayOff:
     case ET::LidOff:
-        LOG_INFO("Device", "IngestSystemEvent", "Policy",
-                 "Sleep event ({}), requesting suspend.",
-                 Host::ToString(ev.type));
+        LOG_INFO("Runtime", __func__, "Policy", "Sleep event ({}), requesting suspend.", Host::ToString(ev.type));
         m_chip.CancelPendingFrameRead();  // abort any blocking GetFrame NOW
         m_stopReason.store(StopReason::ScreenOff);
         break;
     case ET::DisplayOn:
     case ET::LidOn:
     case ET::ResumeAutomatic:
-        LOG_INFO("Device", "IngestSystemEvent", "Policy",
-                 "Wake event ({}), attempting resume.",
-                 Host::ToString(ev.type));
+        LOG_INFO("Runtime", __func__, "Policy", "Wake event ({}), attempting resume.", Host::ToString(ev.type));
         // suspend 状态下直接恢复，无需重建线程
         if (m_state.load() == workerState::suspend) {
-            m_state.store(workerState::ready);
-            LOG_INFO("Device", "IngestSystemEvent", "Policy",
-                     "Resumed from suspend → ready (zero-cost wakeup).");
+            SetState(workerState::ready);
+            LOG_INFO("Runtime", __func__, "Policy", "Resumed from suspend -> ready (zero-cost wakeup).");
         } else {
             Stop();
             Start();
         }
         break;
     case ET::Shutdown:
-        LOG_INFO("Device", "IngestSystemEvent", "Policy",
-                 "Shutdown event, requesting termination.");
+        LOG_INFO("Runtime", __func__, "Policy", "Shutdown event, requesting termination.");
         m_stopReason.store(StopReason::Shutdown);
         break;
     default: break;
@@ -188,9 +181,7 @@ bool DeviceRuntime::DrainCommands() {
         m_lastCmdId = qc.id;
         if (auto r = m_chip.m_afe.SendCommand(qc.cmd); !r) {
             RecordHistory(qc, false, "afe_sendCommand failed");
-            LOG_WARN("Device", "DrainCommands", "CmdExec",
-                     "Command '{}' (type={}) failed — skipping (non-fatal).",
-                     qc.reason, static_cast<int>(qc.cmd.type));
+            LOG_WARN("Runtime", __func__, "CmdExec", "Command '{}' (type={}) failed — skipping (non-fatal).", qc.reason, static_cast<int>(qc.cmd.type));
             // 不再触发 recover: AFE 命令失败不代表 bus 挂了
             continue;
         }
@@ -208,14 +199,12 @@ ThreadResult DeviceRuntime::WorkerMain() {
                                             std::memory_order_acq_rel);
         if (reason != StopReason::None) {
             if (reason == StopReason::ScreenOff) {
-                LOG_INFO("Device", "WorkerMain", "StopReq",
-                         "StopReason::ScreenOff consumed → suspend");
-                m_state.store(workerState::suspend);
+                LOG_INFO("Runtime", __func__, "StopReq", "StopReason::ScreenOff consumed -> suspend");
+                SetState(workerState::suspend);
                 m_needSuspendDeinit = true;   // 延迟到 OnSuspend 首次进入时执行
             } else {
-                LOG_INFO("Device", "WorkerMain", "StopReq",
-                         "StopReason::Shutdown consumed → quit");
-                m_state.store(workerState::quit);
+                LOG_INFO("Runtime", __func__, "StopReq", "StopReason::Shutdown consumed -> quit");
+                SetState(workerState::quit);
             }
             std::lock_guard<std::mutex> lk(m_mu);
             m_cmdQueue.clear();
@@ -232,8 +221,7 @@ ThreadResult DeviceRuntime::WorkerMain() {
         case workerState::quit:
             if (OnQuit()) {
                 m_running.store(false);  // allow restart via Start()
-                LOG_INFO("Device", "WorkerMain", "quit",
-                         "Worker exited, m_running=false.");
+                LOG_INFO("Runtime", __func__, "quit", "Worker exited, m_running=false.");
                 return ThreadResult();
             }
             break;
@@ -247,10 +235,10 @@ ThreadResult DeviceRuntime::WorkerMain() {
 void DeviceRuntime::OnReady() {
     if (m_autoMode.load()) {
         if (auto r = m_chip.Init(); !r) {
-            m_state.store(workerState::recover);
+            SetState(workerState::recover);
             return;
         }
-        m_state.store(workerState::streaming);
+        SetState(workerState::streaming);
     } else {
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
@@ -264,15 +252,11 @@ void DeviceRuntime::OnStreaming() {
         // AFE 命令（如 EnableFreqShift）可能导致一两帧 bus 暂时失响应，不算致命。
         m_consecutiveFrameErrors++;
         if (m_consecutiveFrameErrors >= kMaxConsecutiveFrameErrors) {
-            LOG_ERROR("Device", "OnStreaming", "Streaming",
-                      "{} consecutive GetFrame failures → recover.",
-                      m_consecutiveFrameErrors);
+            LOG_ERROR("Runtime", __func__, "Streaming", "{} consecutive GetFrame failures -> recover.", m_consecutiveFrameErrors);
             m_consecutiveFrameErrors = 0;
-            m_state.store(workerState::recover);
+            SetState(workerState::recover);
         } else {
-            LOG_WARN("Device", "OnStreaming", "Streaming",
-                     "GetFrame failed ({}/{}), retrying...",
-                     m_consecutiveFrameErrors, kMaxConsecutiveFrameErrors);
+            LOG_WARN("Runtime", __func__, "Streaming", "GetFrame failed ({}/{}), retrying...", m_consecutiveFrameErrors, kMaxConsecutiveFrameErrors);
         }
         return;
     }
@@ -342,9 +326,7 @@ void DeviceRuntime::OnSuspend() {
     if (m_needSuspendDeinit) {
         m_chip.HoldReset();
         m_needSuspendDeinit = false;
-        LOG_INFO("Device", "OnSuspend", "suspend",
-                 "Entered suspend, chip reset held low. "
-                 "Waiting for wake event.");
+        LOG_INFO("Runtime", __func__, "suspend", "Entered suspend, chip reset held low. Waiting for wake event.");
     }
     // 低功耗等待，每 100ms 检查一次状态变更
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -355,11 +337,10 @@ void DeviceRuntime::OnRecover() {
 
     // 最大重试 30 次（500ms 间隔 ≈ 15 秒恢复窗口）
     if (m_recoverCount > 30) {
-        LOG_ERROR("Device", "OnRecover", "Recover",
-                  "Exceeded 30 recovery attempts, entering suspend.");
+        LOG_ERROR("Runtime", __func__, "Recover", "Exceeded 30 recovery attempts, entering suspend.");
         m_recoverCount = 0;
         m_needSuspendDeinit = true;
-        m_state.store(workerState::suspend);
+        SetState(workerState::suspend);
         return;
     }
 
@@ -370,14 +351,19 @@ void DeviceRuntime::OnRecover() {
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
-    LOG_INFO("Device", "OnRecover", "Recover",
-             "Recovery attempt {}/30...", m_recoverCount);
+    LOG_INFO("Runtime", __func__, "Recover", "Recovery attempt {}/30...", m_recoverCount);
 
     if (auto res = m_chip.check_bus(); !res) return;
     if (auto res = m_chip.Init(); !res) return;
 
-    LOG_INFO("Device", "OnRecover", "Recover",
-             "Recovery succeeded after {} attempts.", m_recoverCount);
-    m_state.store(workerState::streaming);
+    LOG_INFO("Runtime", __func__, "Recover", "Recovery succeeded after {} attempts.", m_recoverCount);
+    SetState(workerState::streaming);
     m_recoverCount = 0;
+}
+
+void DeviceRuntime::SetState(workerState newState) {
+    workerState old = m_state.exchange(newState, std::memory_order_acq_rel);
+    if (old != newState) {
+        LOG_INFO("Runtime", __func__, "StateTransition", "State changed: {} -> {}", ToString(old), ToString(newState));
+    }
 }

--- a/EGoTouchService/Device/runtime/DeviceRuntime.h
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.h
@@ -146,6 +146,7 @@ private:
     void RecordHistory(const QueuedCommand& qc,
                        bool ok, const std::string& det);
 
+    void SetState(workerState newState);
     std::atomic<workerState> m_state{workerState::quit};
     std::atomic<StopReason> m_stopReason{StopReason::None};
     std::atomic<bool> m_autoMode{false};

--- a/EGoTouchService/Device/vhf/VhfReporter.cpp
+++ b/EGoTouchService/Device/vhf/VhfReporter.cpp
@@ -234,8 +234,7 @@ bool VhfReporter::EnsureDeviceOpen() {
         if (h != INVALID_HANDLE_VALUE) {
             m_handle = h;
             opened = true;
-            LOG_INFO("VhfReporter", "EnsureDeviceOpen", "VHF",
-                     "VHF device opened.");
+            LOG_INFO("VhfReporter", __func__, "VHF", "VHF device opened.");
             break;
         }
     }
@@ -267,10 +266,7 @@ bool VhfReporter::WritePacket(const uint8_t* data, size_t len,
                         &written, nullptr);
     if (!ok || written != len) {
         DWORD err = GetLastError();
-        LOG_WARN("VhfReporter", "WritePacket", "VHF",
-                 "Write {} failed (len={}, written={}, err={}), "
-                 "trying reopen.",
-                 tag, (unsigned)len, (unsigned)written, (unsigned)err);
+        LOG_WARN("VhfReporter", __func__, "VHF", "Write {} failed (len={}, written={}, err={}), trying reopen.", tag, (unsigned)len, (unsigned)written, (unsigned)err);
         ReopenDevice();
         return false;
     }

--- a/EGoTouchService/Engine/StylusSolver/StylusPipeline.cpp
+++ b/EGoTouchService/Engine/StylusSolver/StylusPipeline.cpp
@@ -35,17 +35,14 @@ bool StylusPipeline::ParseSlaveWords(
         std::array<uint16_t, kSlaveWordCount>& out) const {
     const size_t required = kSlaveHeaderBytes + kSlaveWordCount * 2;
     if (rawData.size() < required) {
-        LOG_DEBUG("StylusPipeline", "ParseSlaveWords", "SlaveFrame",
-                  "rawData too small: {} < {}",
-                  rawData.size(), required);
+        LOG_DEBUG("Engine", __func__, "SlaveFrame", "rawData too small: {} < {}",  rawData.size(), required);
         return false;
     }
     if (m_enableSlaveChecksum) {
         uint16_t cs = 0;
         if (!ValidateChecksum16(rawData.data() + kSlaveHeaderBytes,
                                 kSlaveWordCount, cs)) {
-            LOG_DEBUG("StylusPipeline", "ParseSlaveWords", "SlaveFrame",
-                      "Checksum failed: cs=0x{:04X}", cs);
+            LOG_DEBUG("Engine", __func__, "SlaveFrame", "Checksum failed: cs=0x{:04X}",  cs);
             return false;
         }
     }
@@ -131,11 +128,7 @@ bool StylusPipeline::Process(
     {
         static int sAnchorLogCount = 0;
         if ((sAnchorLogCount++ % 60) == 0) {
-            LOG_TRACE("StylusPipeline", "Process", "Anchor",
-                     "anchor=({},{}) grid_center={} sensor=({} rows, {} cols)",
-                     m_gridData.tx1.anchorRow, m_gridData.tx1.anchorCol,
-                     m_gridData.tx1.grid[4][4],
-                     m_sensorRows, m_sensorCols);
+            LOG_TRACE("Engine", __func__, "Anchor", "anchor=({},{}) grid_center={} sensor=({} rows, {} cols)",  m_gridData.tx1.anchorRow, m_gridData.tx1.anchorCol, m_gridData.tx1.grid[4][4], m_sensorRows, m_sensorCols);
         }
     }
 
@@ -250,8 +243,7 @@ bool StylusPipeline::Process(
         }
         static int sPressLogCount = 0;
         if ((sPressLogCount++ % 120) == 0) {
-            LOG_DEBUG("StylusPipeline", "Process", "Pressure",
-                     "btMcu={} active={}", btPress, finalCoor.valid);
+            LOG_DEBUG("Engine", __func__, "Pressure", "btMcu={} active={}",  btPress, finalCoor.valid);
         }
         SolvePressure(btPress, finalCoor.valid);
     }

--- a/EGoTouchService/Host/SystemStateMonitor.cpp
+++ b/EGoTouchService/Host/SystemStateMonitor.cpp
@@ -159,8 +159,7 @@ void SystemStateMonitor::WorkerLoop() {
             INFINITE);
 
         if (wait_result == WAIT_OBJECT_0) {
-            LOG_INFO("Monitor", "WorkerLoop", "Stop",
-                     "Stop event signaled, exiting monitor loop.");
+            LOG_INFO("Host", __func__, "Stop", "Stop event signaled, exiting monitor loop.");
             break;
         }
 
@@ -168,9 +167,7 @@ void SystemStateMonitor::WorkerLoop() {
             const std::size_t event_index = static_cast<std::size_t>(wait_result - WAIT_OBJECT_0 - 1);
             SystemStateEvent event = BuildEvent(event_index);
 
-            LOG_INFO("Monitor", "WorkerLoop", "Signal",
-                     "Named event[{}] signaled → type={}",
-                     event_index, ToString(event.type));
+            LOG_INFO("Host", __func__, "Signal", "Named event[{}] signaled → type={}",  event_index, ToString(event.type));
 
             if (m_callback) {
                 m_callback(event);
@@ -185,9 +182,7 @@ void SystemStateMonitor::WorkerLoop() {
         }
 
         // WAIT_FAILED/WAIT_ABANDONED are treated as hard stop for this monitor instance.
-        LOG_WARN("Monitor", "WorkerLoop", "Error",
-                 "WaitForMultipleObjects returned unexpected result: {}",
-                 wait_result);
+        LOG_WARN("Host", __func__, "Error", "WaitForMultipleObjects returned unexpected result: {}",  wait_result);
         break;
     }
 

--- a/EGoTouchService/source/ServiceEntry.cpp
+++ b/EGoTouchService/source/ServiceEntry.cpp
@@ -139,8 +139,7 @@ int wmain(int argc, wchar_t* argv[]) {
     Common::Logger::Init("EGoTouchService", "C:/ProgramData/EGoTouchRev/logs/",
                           Common::GuiLogSink::Instance());
 
-    LOG_INFO("Shell", "wmain", "Boot",
-             "Process priority set to REALTIME_PRIORITY_CLASS.");
+    LOG_INFO("Service", __func__, "Boot", "Process priority set to REALTIME_PRIORITY_CLASS.");
 
     const bool consoleMode =
         (argc >= 2 && std::wstring_view(argv[1]) == L"--console");
@@ -158,14 +157,10 @@ int wmain(int argc, wchar_t* argv[]) {
             DWORD err = GetLastError();
             if (err == ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) {
                 // 双击运行或无 SCM 环境 → 退回控制台
-                LOG_WARN("Shell", "wmain", "Boot",
-                         "Not launched by SCM (err={}), "
-                         "falling back to console mode.", err);
+                LOG_WARN("Service", __func__, "Boot", "Not launched by SCM (err={}), falling back to console mode.", err);
                 Service::ServiceShell::Instance()->RunAsConsole();
             } else {
-                LOG_ERROR("Shell", "wmain", "Boot",
-                          "StartServiceCtrlDispatcherW failed, "
-                          "err={}.", err);
+                LOG_ERROR("Service", __func__, "Boot", "StartServiceCtrlDispatcherW failed, err={}.", err);
             }
         }
     }

--- a/EGoTouchService/source/ServiceHost.cpp
+++ b/EGoTouchService/source/ServiceHost.cpp
@@ -74,10 +74,7 @@ void ServiceHost::ParseServiceConfig(const std::string& configPath) {
 bool ServiceHost::Start() {
     // ── 0. 解析运行模式 ──────────────────────────────────
     ParseServiceConfig(kConfigPath);
-    LOG_INFO("ServiceHost", "Start", "Boot",
-             "Service mode: {}, AutoMode: {}",
-             m_mode == ServiceMode::Full ? "full" : "touch_only",
-             m_autoMode);
+    LOG_INFO("Service", __func__, "Boot", "Service mode: {}, AutoMode: {}", m_mode == ServiceMode::Full ? "full" : "touch_only", m_autoMode);
 
     // ── 1. DeviceRuntime（先创建，后续模块依赖它） ─────────
     m_deviceRuntime = std::make_unique<DeviceRuntime>(
@@ -88,41 +85,32 @@ bool ServiceHost::Start() {
     BuildDefaultPipeline(kConfigPath);
 
     if (!m_deviceRuntime->Start()) {
-        LOG_ERROR("ServiceHost", "Start", "Boot",
-                  "DeviceRuntime::Start() failed.");
+        LOG_ERROR("Service", __func__, "Boot", "DeviceRuntime::Start() failed.");
         return false;
     }
-    LOG_INFO("ServiceHost", "Start", "Boot",
-             "DeviceRuntime started (auto mode).");
+    LOG_INFO("Service", __func__, "Boot", "DeviceRuntime started (auto mode).");
 
     // ── 2. SystemStateMonitor（事件 → DeviceRuntime 命令队列） ─
     m_sysMonitor = std::make_unique<Host::SystemStateMonitor>();
     bool monitorOk = m_sysMonitor->Start(
         [this](const Host::SystemStateEvent& ev) {
-            LOG_INFO("ServiceHost", "SystemEventCb", "Event",
-                     "System event: type={}",
-                     Host::ToString(ev.type));
+            LOG_INFO("Service", __func__, "Event", "System event: type={}", Host::ToString(ev.type));
             m_deviceRuntime->IngestSystemEvent(ev);
         });
 
     if (!monitorOk) {
-        LOG_WARN("ServiceHost", "Start", "Monitor",
-                 "SystemStateMonitor failed to start; "
-                 "running without system state detection.");
+        LOG_WARN("Service", __func__, "Monitor", "SystemStateMonitor failed to start; running without system state detection.");
         m_sysMonitor.reset();
     } else {
-        LOG_INFO("ServiceHost", "Start", "Monitor",
-                 "SystemStateMonitor started.");
+        LOG_INFO("Service", __func__, "Monitor", "SystemStateMonitor started.");
     }
 
 #ifdef _DEBUG
     // ── 3. Shared Memory (Service creates Global\\ mapping, debug only) ──
     if (!m_frameWriter.Create(Ipc::kSharedFrameName)) {
-        LOG_WARN("ServiceHost", "Start", "IPC",
-                 "Failed to create shared memory; App debug will be disabled.");
+        LOG_WARN("Service", __func__, "IPC", "Failed to create shared memory; App debug will be disabled.");
     } else {
-        LOG_INFO("ServiceHost", "Start", "IPC",
-                 "Shared memory created for App connection.");
+        LOG_INFO("Service", __func__, "IPC", "Shared memory created for App connection.");
     }
 #endif
 
@@ -138,15 +126,13 @@ bool ServiceHost::Start() {
         sa.bInheritHandle = FALSE;
         m_logEvent = CreateEventW(&sa, FALSE, FALSE, Ipc::kLogReadyEventName);
         if (!m_logEvent) {
-            LOG_WARN("ServiceHost", "Start", "IPC",
-                     "CreateEvent failed for LogReadyEvent: {}", GetLastError());
+            LOG_WARN("Service", __func__, "IPC", "CreateEvent failed for LogReadyEvent: {}", GetLastError());
         } else {
             Common::GuiLogSink::Instance()->SetNotifyEvent(m_logEvent);
         }
         m_penEvent = CreateEventW(&sa, FALSE, FALSE, Ipc::kPenReadyEventName);
         if (!m_penEvent) {
-            LOG_WARN("ServiceHost", "Start", "IPC",
-                     "CreateEvent failed for PenReadyEvent: {}", GetLastError());
+            LOG_WARN("Service", __func__, "IPC", "CreateEvent failed for PenReadyEvent: {}", GetLastError());
         }
     }
     m_configDirty.Open();
@@ -155,11 +141,9 @@ bool ServiceHost::Start() {
             return HandleIpcCommand(req);
         });
     m_ipcServer.Start();
-    LOG_INFO("ServiceHost", "Start", "Boot",
-             "IPC pipe server started.");
+    LOG_INFO("Service", __func__, "Boot", "IPC pipe server started.");
 
-    LOG_INFO("ServiceHost", "Start", "Boot",
-             "All modules started.");
+    LOG_INFO("Service", __func__, "Boot", "All modules started.");
 
     // ── 4. BT MCU（仅 Full 模式启用） ─────────────────────
     if (m_mode == ServiceMode::Full) {
@@ -173,9 +157,7 @@ bool ServiceHost::Start() {
 
                 case EC::PenConnStatus: {
                     const bool connected = !ev.payload.empty() && ev.payload[0] != 0;
-                    LOG_INFO("ServiceHost", "PenEventCb", "MCU",
-                             "PenConnStatus: {}.",
-                             connected ? "connected" : "disconnected");
+                    LOG_INFO("Service", __func__, "MCU", "PenConnStatus: {}.", connected ? "connected" : "disconnected");
                     if (m_deviceRuntime) {
                         command cmd{};
                         if (connected) {
@@ -200,9 +182,7 @@ bool ServiceHost::Start() {
                         snprintf(buf, sizeof(buf), "%02X ", ev.payload[i]);
                         hexDump += buf;
                     }
-                    LOG_INFO("ServiceHost", "PenEventCb", "MCU",
-                             "PenFreqJump (payload[{}]: {})",
-                             ev.payload.size(), hexDump);
+                    LOG_INFO("Service", __func__, "MCU", "PenFreqJump (payload[{}]: {})", ev.payload.size(), hexDump);
 
                     if (m_deviceRuntime) {
                         command cmd{};
@@ -217,8 +197,7 @@ bool ServiceHost::Start() {
                 case EC::PenTypeInfo: {
                     // 0x73: 笔类型 → set_stylus_id(pen_type) 频率表绑定
                     uint8_t penType = ev.payload.empty() ? 0 : ev.payload[0];
-                    LOG_INFO("ServiceHost", "PenEventCb", "MCU",
-                             "PenTypeInfo: pen_type={}.", penType);
+                    LOG_INFO("Service", __func__, "MCU", "PenTypeInfo: pen_type={}.", penType);
                     if (m_deviceRuntime) {
                         command cmd{};
                         cmd.type  = AFE_Command::SetStylusId;
@@ -236,21 +215,17 @@ bool ServiceHost::Start() {
                     if (mode == 1) modeStr = "writing";
                     else if (mode == 2) modeStr = "hovering";
                     else if (mode == 3) modeStr = "eraser";
-                    LOG_INFO("ServiceHost", "PenEventCb", "MCU",
-                             "PenCurStatus: mode={} ({}).", mode, modeStr);
+                    LOG_INFO("Service", __func__, "MCU", "PenCurStatus: mode={} ({}).", mode, modeStr);
                     break;
                 }
 
                 default:
-                    LOG_INFO("ServiceHost", "PenEventCb", "MCU",
-                             "MCU event 0x{:02X} received.",
-                             static_cast<uint8_t>(ev.code));
+                    LOG_INFO("Service", __func__, "MCU", "MCU event 0x{:02X} received.", static_cast<uint8_t>(ev.code));
                     break;
                 }
             });
         m_penEventBridge->Start();
-        LOG_INFO("ServiceHost", "Start", "MCU",
-                 "PenEventBridge started (col00 event channel).");
+        LOG_INFO("Service", __func__, "MCU", "PenEventBridge started (col00 event channel).");
 
         // ── 4b. 压力通道 (col01): 'U' 报文频率 + 压感 ──────
         m_penPressureReader = std::make_unique<Himax::Pen::PenPressureReader>();
@@ -271,11 +246,9 @@ bool ServiceHost::Start() {
         }
 
         m_penPressureReader->Start();
-        LOG_INFO("ServiceHost", "Start", "MCU",
-                 "PenPressureReader started (col01 pressure channel).");
+        LOG_INFO("Service", __func__, "MCU", "PenPressureReader started (col01 pressure channel).");
     } else {
-        LOG_INFO("ServiceHost", "Start", "MCU",
-                 "Pen modules skipped (touch_only mode).");
+        LOG_INFO("Service", __func__, "MCU", "Pen modules skipped (touch_only mode).");
     }
 
     return true;
@@ -302,33 +275,28 @@ void ServiceHost::Stop() {
     if (m_penPressureReader) {
         m_penPressureReader->Stop();
         m_penPressureReader.reset();
-        LOG_INFO("ServiceHost", "Stop", "MCU",
-                 "PenPressureReader stopped.");
+        LOG_INFO("Service", __func__, "MCU", "PenPressureReader stopped.");
     }
     if (m_penEventBridge) {
         m_penEventBridge->Stop();
         m_penEventBridge.reset();
-        LOG_INFO("ServiceHost", "Stop", "MCU",
-                 "PenEventBridge stopped.");
+        LOG_INFO("Service", __func__, "MCU", "PenEventBridge stopped.");
     }
 
     if (m_sysMonitor) {
 
         m_sysMonitor->Stop();
         m_sysMonitor.reset();
-        LOG_INFO("ServiceHost", "Stop", "Monitor",
-                 "SystemStateMonitor stopped.");
+        LOG_INFO("Service", __func__, "Monitor", "SystemStateMonitor stopped.");
     }
 
     if (m_deviceRuntime) {
         m_deviceRuntime->Stop();
         m_deviceRuntime.reset();
-        LOG_INFO("ServiceHost", "Stop", "Device",
-                 "DeviceRuntime stopped.");
+        LOG_INFO("Service", __func__, "Device", "DeviceRuntime stopped.");
     }
 
-    LOG_INFO("ServiceHost", "Stop", "Shutdown",
-             "All modules stopped.");
+    LOG_INFO("Service", __func__, "Shutdown", "All modules stopped.");
 }
 
 // ── Pipeline 构建 ──────────────────────────────
@@ -342,9 +310,7 @@ void ServiceHost::BuildDefaultPipeline(const std::string& configPath) {
     pl.AddProcessor(std::make_unique<Engine::TouchTracker>());
     pl.AddProcessor(std::make_unique<Engine::CoordinateFilter>());
     pl.AddProcessor(std::make_unique<Engine::TouchGestureStateMachine>());
-    LOG_INFO("ServiceHost", "BuildDefaultPipeline", "Boot",
-             "Registered {} pipeline processors.",
-             pl.GetProcessors().size());
+    LOG_INFO("Service", __func__, "Boot", "Registered {} pipeline processors.", pl.GetProcessors().size());
 
     // Load saved config
     std::ifstream cfgIn(configPath);
@@ -369,11 +335,9 @@ void ServiceHost::BuildDefaultPipeline(const std::string& configPath) {
                 }
             }
         }
-        LOG_INFO("ServiceHost", "BuildDefaultPipeline", "Boot",
-                 "Loaded config from {}.", configPath);
+        LOG_INFO("Service", __func__, "Boot", "Loaded config from {}.", configPath);
     } else {
-        LOG_WARN("ServiceHost", "BuildDefaultPipeline", "Boot",
-                 "Config file not found: {}", configPath);
+        LOG_WARN("Service", __func__, "Boot", "Config file not found: {}", configPath);
     }
 }
 
@@ -397,15 +361,12 @@ Ipc::IpcResponse ServiceHost::HandleIpcCommand(
                 });
             m_debugMode = true;
             resp.success = true;
-            LOG_INFO("ServiceHost", "HandleIpcCommand", "IPC",
-                     "Entered debug mode.");
+            LOG_INFO("Service", __func__, "IPC", "Entered debug mode.");
         } else {
-            LOG_ERROR("ServiceHost", "HandleIpcCommand", "IPC",
-                      "EnterDebugMode rejected: shared memory not available.");
+            LOG_ERROR("Service", __func__, "IPC", "EnterDebugMode rejected: shared memory not available.");
         }
 #else
-        LOG_WARN("ServiceHost", "HandleIpcCommand", "IPC",
-                 "EnterDebugMode not available in release build.");
+        LOG_WARN("Service", __func__, "IPC", "EnterDebugMode not available in release build.");
 #endif
         break;
     }
@@ -416,8 +377,7 @@ Ipc::IpcResponse ServiceHost::HandleIpcCommand(
         m_debugMode = false;
 #endif
         resp.success = true;
-        LOG_INFO("ServiceHost", "HandleIpcCommand", "IPC",
-                 "Exited debug mode.");
+        LOG_INFO("Service", __func__, "IPC", "Exited debug mode.");
         break;
 
     case Ipc::IpcCommand::AfeCommand:
@@ -476,8 +436,7 @@ Ipc::IpcResponse ServiceHost::HandleIpcCommand(
                     }
                 }
                 resp.success = true;
-                LOG_INFO("ServiceHost", "HandleIpcCommand", "IPC",
-                         "Config reloaded from {}.", kConfigPath);
+                LOG_INFO("Service", __func__, "IPC", "Config reloaded from {}.", kConfigPath);
             }
         }
         break;
@@ -498,8 +457,7 @@ Ipc::IpcResponse ServiceHost::HandleIpcCommand(
                     out << "\n";
                 }
                 resp.success = true;
-                LOG_INFO("ServiceHost", "HandleIpcCommand", "IPC",
-                         "Config saved to {}.", kConfigPath);
+                LOG_INFO("Service", __func__, "IPC", "Config saved to {}.", kConfigPath);
             }
         }
         break;

--- a/EGoTouchService/source/ServiceShell.cpp
+++ b/EGoTouchService/source/ServiceShell.cpp
@@ -21,19 +21,16 @@ void WINAPI ServiceShell::SvcMain(DWORD argc, LPWSTR* argv) {
     s->m_statusHandle = RegisterServiceCtrlHandlerExW(
         kServiceName, SvcCtrlHandlerEx, s);
     if (!s->m_statusHandle) {
-        LOG_ERROR("Shell", "SvcMain", "Boot",
-                  "RegisterServiceCtrlHandlerExW failed.");
+        LOG_ERROR("Service", __func__, "Boot", "RegisterServiceCtrlHandlerExW failed.");
         return;
     }
 
     s->ReportStatus(SERVICE_START_PENDING, 3000);
     s->m_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    LOG_INFO("Shell", "SvcMain", "Boot",
-             "Starting modules...");
+    LOG_INFO("Service", __func__, "Boot", "Starting modules...");
     if (!s->m_host.Start()) {
-        LOG_ERROR("Shell", "SvcMain", "Boot",
-                  "ServiceHost::Start() failed.");
+        LOG_ERROR("Service", __func__, "Boot", "ServiceHost::Start() failed.");
         s->ReportStatus(SERVICE_STOPPED);
         return;
     }
@@ -41,13 +38,12 @@ void WINAPI ServiceShell::SvcMain(DWORD argc, LPWSTR* argv) {
     s->RegisterPowerNotifications();
 
     s->ReportStatus(SERVICE_RUNNING);
-    LOG_INFO("Shell", "SvcMain", "Running",
-             "Service is running. Waiting for stop signal...");
+    LOG_INFO("Service", __func__, "Running", "Service is running. Waiting for stop signal...");
     s->WaitForStop();
     s->UnregisterPowerNotifications();
     s->m_host.Stop();
     s->ReportStatus(SERVICE_STOPPED);
-    LOG_INFO("Shell", "SvcMain", "Stopped", "Service stopped.");
+    LOG_INFO("Service", __func__, "Stopped", "Service stopped.");
 }
 
 DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
@@ -66,8 +62,7 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
     case SERVICE_CONTROL_STOP:
     case SERVICE_CONTROL_SHUTDOWN:
     case SERVICE_CONTROL_PRESHUTDOWN:
-        LOG_INFO("Shell", "CtrlHandler", "Stopping",
-                 "Received stop/shutdown control code={}.", ctrl);
+        LOG_INFO("Service", __func__, "Stopping", "Received stop/shutdown control code={}.", ctrl);
         // Signal MonitorShutDownEvent (index 6) so monitor thread sees it
         signalEvent(6);
         s->ReportStatus(SERVICE_STOP_PENDING, 5000);
@@ -77,7 +72,7 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
     case SERVICE_CONTROL_POWEREVENT: {
         // Handle PBT_APMRESUMEAUTOMATIC (system resumed from sleep)
         if (evtType == PBT_APMRESUMEAUTOMATIC) {
-            LOG_INFO("Shell", "PBT", "Power", "PBT_APMRESUMEAUTOMATIC");
+            LOG_INFO("Service", __func__, "Power", "PBT_APMRESUMEAUTOMATIC");
             signalEvent(7);  // PBT_APMRESUMEAUTOMATIC event
             return NO_ERROR;
         }
@@ -97,8 +92,7 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
 
         if (pbs->PowerSetting == kDisplayGuid && pbs->DataLength >= 4) {
             DWORD state = *reinterpret_cast<DWORD*>(pbs->Data);
-            LOG_INFO("Shell", "PBT", "Power",
-                     "GUID_CONSOLE_DISPLAY_STATE = {}", state);
+            LOG_INFO("Service", __func__, "Power", "GUID_CONSOLE_DISPLAY_STATE = {}", state);
             if (state >= 1) {
                 signalEvent(0);  // MonitorPowerOnEvent
                 signalEvent(2);  // MonitorConsoleDisplayOnEvent
@@ -109,8 +103,7 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
         }
         else if (pbs->PowerSetting == kLidGuid && pbs->DataLength >= 4) {
             DWORD state = *reinterpret_cast<DWORD*>(pbs->Data);
-            LOG_INFO("Shell", "PBT", "Power",
-                     "GUID_LIDSWITCH_STATE = {} (1=open, 0=closed)", state);
+            LOG_INFO("Service", __func__, "Power", "GUID_LIDSWITCH_STATE = {} (1=open, 0=closed)", state);
             if (state == 1) {
                 signalEvent(4);  // MonitorLidOnEvent
             } else {
@@ -137,19 +130,16 @@ void ServiceShell::RunAsConsole() {
         return TRUE;
     }, TRUE);
 
-    LOG_INFO("Shell", "RunAsConsole", "Boot",
-             "Starting modules (console mode)...");
+    LOG_INFO("Service", __func__, "Boot", "Starting modules (console mode)...");
     if (!m_host.Start()) {
-        LOG_ERROR("Shell", "RunAsConsole", "Boot",
-                  "ServiceHost::Start() failed.");
+        LOG_ERROR("Service", __func__, "Boot", "ServiceHost::Start() failed.");
         return;
     }
 
-    LOG_INFO("Shell", "RunAsConsole", "Running",
-             "Service running in console mode. Press Ctrl+C to stop.");
+    LOG_INFO("Service", __func__, "Running", "Service running in console mode. Press Ctrl+C to stop.");
     WaitForStop();
     m_host.Stop();
-    LOG_INFO("Shell", "RunAsConsole", "Stopped", "Console mode stopped.");
+    LOG_INFO("Service", __func__, "Stopped", "Console mode stopped.");
 }
 
 // ─── 辅助 ────────────────────────────────────
@@ -213,11 +203,7 @@ void ServiceShell::RegisterPowerNotifications() {
     m_hSuspendNotify = RegisterPowerSettingNotification(
         m_statusHandle, &kAwayGuid, DEVICE_NOTIFY_SERVICE_HANDLE);
 
-    LOG_INFO("Shell", "RegisterPowerNotifications", "Power",
-             "Registered PBT notifications (display={}, lid={}, away={}).",
-             m_hDisplayNotify != nullptr,
-             m_hLidNotify != nullptr,
-             m_hSuspendNotify != nullptr);
+    LOG_INFO("Service", __func__, "Power", "Registered PBT notifications (display={}, lid={}, away={}).", m_hDisplayNotify != nullptr, m_hLidNotify != nullptr, m_hSuspendNotify != nullptr);
 }
 
 void ServiceShell::UnregisterPowerNotifications() {

--- a/Tools/BtMcuTestTool/BtMcuTestTool.cpp
+++ b/Tools/BtMcuTestTool/BtMcuTestTool.cpp
@@ -424,7 +424,7 @@ int main(int, char**)
     // freopen_s(&dummy, "CONOUT$", "w", stderr);
 
     Common::Logger::Init("BtMcuTestTool");
-    LOG_INFO("Tool", "main", "System", "--- BtMcuTestTool Starts ---");
+    LOG_INFO("Tool", __func__, "System", "--- BtMcuTestTool Starts ---");
 
     g_evtTransport = Himax::Pen::CreatePenUsbTransportWin32();
     g_pressTransport = Himax::Pen::CreatePenUsbTransportWin32();
@@ -517,24 +517,24 @@ int main(int, char**)
             if (evtPath.has_value()) {
                 auto res = g_evtTransport->Open(evtPath.value());
                 if (res.has_value()) {
-                    LOG_INFO("Tool", "Open", "Evt", "Event channel connected.");
+                    LOG_INFO("Tool", __func__, "Evt", "Event channel connected.");
                 } else {
-                    LOG_ERROR("Tool", "Open", "Evt", "Failed to open event channel.");
+                    LOG_ERROR("Tool", __func__, "Evt", "Failed to open event channel.");
                 }
             } else {
-                LOG_ERROR("Tool", "Open", "Evt", "Event device not found.");
+                LOG_ERROR("Tool", __func__, "Evt", "Event device not found.");
             }
             // Pressure channel
             auto pressPath = FindPressureDevicePath();
             if (pressPath.has_value()) {
                 auto res = g_pressTransport->Open(pressPath.value());
                 if (res.has_value()) {
-                    LOG_INFO("Tool", "Open", "Press", "Pressure channel connected.");
+                    LOG_INFO("Tool", __func__, "Press", "Pressure channel connected.");
                 } else {
-                    LOG_ERROR("Tool", "Open", "Press", "Failed to open pressure channel.");
+                    LOG_ERROR("Tool", __func__, "Press", "Failed to open pressure channel.");
                 }
             } else {
-                LOG_ERROR("Tool", "Open", "Press", "Pressure HID device not found.");
+                LOG_ERROR("Tool", __func__, "Press", "Pressure HID device not found.");
             }
 
             // Auto-handshake in background thread

--- a/Tools/EGoTouchApp/source/ApplicationEntry.cpp
+++ b/Tools/EGoTouchApp/source/ApplicationEntry.cpp
@@ -31,7 +31,7 @@ int main(int, char**)
     // 启动日志框架 (所有日志通过 GuiLogSink 在 Log 面板显示)
     Common::Logger::Init("EGoTouch", "C:/ProgramData/EGoTouchRev/logs/",
                           Common::GuiLogSink::Instance());
-    LOG_INFO("App", "wWinMain", "System", "--- EGoTouchApp (DX11) Starts ---");
+    LOG_INFO("App", __func__, "System", "--- EGoTouchApp (DX11) Starts ---");
 
     // 1. 创建 ServiceProxy（后台自动发现 Service）
     App::ServiceProxy serviceProxy;

--- a/Tools/EGoTouchApp/source/DiagnosticsWorkbench.cpp
+++ b/Tools/EGoTouchApp/source/DiagnosticsWorkbench.cpp
@@ -1200,7 +1200,7 @@ void DiagnosticsWorkbench::ExportCurrentFrameToCSV(bool isAutoCapture) {
     std::error_code ec;
     std::filesystem::create_directories(dir, ec);
     if (ec) {
-        LOG_ERROR("App", "DiagnosticsWorkbench::ExportCurrentFrameToCSV", "System", "Failed to create directory: {}", dir.string());
+        LOG_ERROR("App", __func__, "UI", "Failed to create directory: {}", dir.string());
     }
     
     // We add a high-resolution counter parameter or thread ID to absolutely guarantee no overwrites
@@ -1218,7 +1218,7 @@ void DiagnosticsWorkbench::ExportCurrentFrameToCSV(bool isAutoCapture) {
 
     std::ofstream out(fullPath.string());
     if (!out.is_open()) {
-        LOG_INFO("App", "DiagnosticsWorkbench::ExportCurrentFrameToCSV", "Error", "Failed to open file for writing: {}", fullPath.string());
+        LOG_INFO("App", __func__, "UI", "Failed to open file for writing: {}", fullPath.string());
         return;
     }
 
@@ -1389,7 +1389,7 @@ void DiagnosticsWorkbench::ExportCurrentFrameToCSV(bool isAutoCapture) {
     }
 
     out.close();
-    LOG_INFO("App", "DiagnosticsWorkbench::ExportCurrentFrameToCSV", "UI", "Frame exported to {}", fullPath.string());
+    LOG_INFO("App", __func__, "UI", "Frame exported to {}", fullPath.string());
 }
 
 // ── BT MCU Panel (PenBridge Status — via IPC) ──
@@ -1505,11 +1505,9 @@ void DiagnosticsWorkbench::DrawSystemEventsPanel() {
             if (h) {
                 SetEvent(h);
                 CloseHandle(h);
-                LOG_INFO("App", "SystemEvents", "UI", "Signaled: {}", item.label);
+                LOG_INFO("App", __func__, "UI", "Signaled: {}", item.label);
             } else {
-                LOG_WARN("App", "SystemEvents", "UI",
-                         "Failed to open event (index={}, err={})",
-                         item.index, GetLastError());
+                LOG_WARN("App", __func__, "UI", "Failed to open event (index={}, err={})", item.index, GetLastError());
             }
         }
         ImGui::PopStyleColor(2);

--- a/Tools/EGoTouchApp/source/ServiceProxy.cpp
+++ b/Tools/EGoTouchApp/source/ServiceProxy.cpp
@@ -49,8 +49,7 @@ ServiceProxy::~ServiceProxy() {
 bool ServiceProxy::Connect() {
     // 1. Open shared memory (Service owns the Global\\ mapping)
     if (!m_frameReader.Open(kSharedMemName)) {
-        LOG_ERROR("App", "ServiceProxy::Connect", "IPC",
-                  "Failed to open shared memory (Service not running?).");
+        LOG_ERROR("App", __func__, "IPC", "Failed to open shared memory (Service not running?).");
         return false;
     }
     // 2. Open config dirty flag
@@ -58,16 +57,14 @@ bool ServiceProxy::Connect() {
 
     // 3. Connect pipe to Service
     if (!m_client.Connect(3000)) {
-        LOG_ERROR("App", "ServiceProxy::Connect", "IPC",
-                  "Pipe connection failed.");
+        LOG_ERROR("App", __func__, "IPC", "Pipe connection failed.");
         m_frameReader.Close();
         return false;
     }
     // 4. Tell Service to enter debug mode
     auto resp = m_client.EnterDebugMode(kSharedMemName);
     if (!resp.success) {
-        LOG_ERROR("App", "ServiceProxy::Connect", "IPC",
-                  "EnterDebugMode rejected.");
+        LOG_ERROR("App", __func__, "IPC", "EnterDebugMode rejected.");
         m_client.Disconnect();
         m_frameReader.Close();
         return false;
@@ -75,30 +72,26 @@ bool ServiceProxy::Connect() {
     if (!m_logEvent) {
         m_logEvent = OpenEventW(SYNCHRONIZE, FALSE, Ipc::kLogReadyEventName);
         if (!m_logEvent) {
-            LOG_WARN("App", "ServiceProxy::Connect", "IPC",
-                     "OpenEvent failed for LogReadyEvent: {}", GetLastError());
+            LOG_WARN("App", __func__, "IPC", "OpenEvent failed for LogReadyEvent: {}", GetLastError());
         }
     }
     if (!m_penEvent) {
         m_penEvent = OpenEventW(SYNCHRONIZE, FALSE, Ipc::kPenReadyEventName);
         if (!m_penEvent) {
-            LOG_WARN("App", "ServiceProxy::Connect", "IPC",
-                     "OpenEvent failed for PenReadyEvent: {}", GetLastError());
+            LOG_WARN("App", __func__, "IPC", "OpenEvent failed for PenReadyEvent: {}", GetLastError());
         }
     }
     if (!m_pollStopEvent) {
         m_pollStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
         if (!m_pollStopEvent) {
-            LOG_WARN("App", "ServiceProxy::Connect", "IPC",
-                     "CreateEvent failed for PollStopEvent: {}", GetLastError());
+            LOG_WARN("App", __func__, "IPC", "CreateEvent failed for PollStopEvent: {}", GetLastError());
         }
     }
     // 5. Start polling thread
     m_polling.store(true);
     m_pollThread = std::thread(&ServiceProxy::PollLoop, this);
 
-    LOG_INFO("App", "ServiceProxy::Connect", "IPC",
-             "Connected to EGoTouchService.");
+    LOG_INFO("App", __func__, "IPC", "Connected to EGoTouchService.");
     return true;
 }
 
@@ -131,8 +124,7 @@ void ServiceProxy::Disconnect() {
     m_configDirty.Close();
     m_fps.store(0);
     m_slaveFps.store(0);
-    LOG_INFO("App", "ServiceProxy::Disconnect", "IPC",
-             "Disconnected.");
+    LOG_INFO("App", __func__, "IPC", "Disconnected.");
 }
 
 // ── Auto-discovery ──
@@ -141,8 +133,7 @@ void ServiceProxy::StartAutoDiscovery(int intervalMs) {
     m_discoveryIntervalMs = intervalMs;
     m_discovering.store(true);
     m_discoveryThread = std::thread(&ServiceProxy::DiscoveryLoop, this);
-    LOG_INFO("App", "ServiceProxy::StartAutoDiscovery", "IPC",
-             "Auto-discovery started (interval={}ms).", intervalMs);
+    LOG_INFO("App", __func__, "IPC", "Auto-discovery started (interval={}ms).", intervalMs);
 }
 
 void ServiceProxy::StopAutoDiscovery() {
@@ -159,8 +150,7 @@ void ServiceProxy::DiscoveryLoop() {
     while (m_discovering.load()) {
         if (!IsConnected()) {
             if (Connect()) {
-                LOG_INFO("App", "ServiceProxy::DiscoveryLoop", "IPC",
-                         "Service discovered and connected.");
+                LOG_INFO("App", __func__, "IPC", "Service discovered and connected.");
             }
         }
         // Sleep in small increments so we can stop quickly
@@ -220,8 +210,7 @@ void ServiceProxy::SaveConfig() {
     // Notify Service to reload from config.ini
     m_configDirty.SetDirty();
     m_client.ReloadConfig();
-    LOG_INFO("App", "ServiceProxy::SaveConfig", "Config",
-             "Config saved and Service notified to reload.");
+    LOG_INFO("App", __func__, "IPC", "Config saved and Service notified to reload.");
 }
 
 void ServiceProxy::LoadConfig() {
@@ -339,8 +328,7 @@ void ServiceProxy::TriggerDVRExport(bool heatmap, bool master, bool slave) {
             }
         }
     }
-    LOG_INFO("App", "ServiceProxy::TriggerDVRExport", "DVR",
-             "Exported {} frames to {}/", frames.size(), dir);
+    LOG_INFO("App", __func__, "IPC", "Exported {} frames to {}/", frames.size(), dir);
 }
 
 // ── Poll loop with FPS measurement ──


### PR DESCRIPTION
- Standardized all LOG_* macro calls to the 4-parameter format ([Layer] [Method] [State] Message) across EGoTouchService and EGoTouchApp modules to fix compilation errors.
- Suppressed non-discardable warnings in return values.