### PR TITLE
Fix service installation failure and add Chinese localization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(EGoTouchRev VERSION 0.1.0 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Use static MSVC runtime to avoid missing VCRUNTIME140.dll on target machines
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 # --- Platform compatibility ---
 # Prevent Windows.h from defining min/max macros that conflict with std::min/std::max
 # Suppress MSVC CRT deprecation warnings (e.g. localtime -> localtime_s)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ninja
 
 # 2. Package the MSI Installer (Requires .NET)
 cd ..
-wix build -arch arm64 scripts/EGoTouchSetup.wxs -ext WixToolset.UI.wixext -o build/EGoTouch_ARM64_v1.0.msi
+wix build -arch arm64 scripts/EGoTouchSetup.wxs -ext WixToolset.UI.wixext -loc scripts/zh-CN.wxl -o build/EGoTouch_ARM64_v1.0.msi
 ```
 
 ---

--- a/scripts/EGoTouchSetup.wxs
+++ b/scripts/EGoTouchSetup.wxs
@@ -5,16 +5,17 @@
     - UpgradeCode 必须全局唯一，绝不能改，用于覆盖更新旧版本。
     - 我们使用 -arch arm64 命令行参数来设定原生架构
   -->
-  <Package Name="EGoTouch Controller Software" Manufacturer="EGoTouch Team" Version="1.0.0" 
+  <Package Name="!(loc.ProductName)" Manufacturer="!(loc.Manufacturer)" Version="1.0.0"
            UpgradeCode="434AC770-0762-431A-9ABC-DB2F9DB289AC" 
-           Scope="perMachine">
+           Scope="perMachine"
+           Language="!(loc.Language)">
 
     <!-- 支持自动覆盖升级：只要 UpgradeCode 不变，且提升 Version 号，它就会自动卸载旧版并覆盖安装新版 -->
-    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." AllowSameVersionUpgrades="yes" />
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" AllowSameVersionUpgrades="yes" />
 
     <!-- 开启基础的安装界面 UI (会提供一个“我同意”“下一步”“安装”的向导) -->
     <ui:WixUI Id="WixUI_Minimal" />
-    <WixVariable Id="WixUILicenseRtf" Value="scripts\\EULA.rtf" />
+    <WixVariable Id="WixUILicenseRtf" Value="!(loc.LicenseRtf)" />
 
     <!-- 用 CAB 文件打包我们所有零散文件并嵌在单个 MSI 内 -->
     <MediaTemplate EmbedCab="yes" />
@@ -36,8 +37,8 @@
             Id="EGoTouchServiceInstaller"
             Type="ownProcess"
             Name="EGoTouchService"
-            DisplayName="EGoTouch Capacitive Touch Driver"
-            Description="EGoTouch Capacitive Touch Driver Service - Manages touch frame acquisition, algorithm processing, and HID injection."
+            DisplayName="!(loc.ServiceDisplayName)"
+            Description="!(loc.ServiceDescription)"
             Start="auto"           
             Account="LocalSystem"
             ErrorControl="normal" />

--- a/scripts/EGoTouchTestSetup.wxs
+++ b/scripts/EGoTouchTestSetup.wxs
@@ -4,15 +4,16 @@
     测试版本安装包声明区：
     包含完整的诊断上位机与测试工具。
   -->
-  <Package Name="EGoTouch Controller Software (Test Version)" Manufacturer="EGoTouch Team" Version="1.9.9" 
+  <Package Name="!(loc.ProductNameTest)" Manufacturer="!(loc.Manufacturer)" Version="1.9.9"
            UpgradeCode="434AC770-0762-431A-9ABC-DB2F9DB289AD" 
-           Scope="perMachine">
+           Scope="perMachine"
+           Language="!(loc.Language)">
 
     <!-- 支持自动覆盖升级 -->
-    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." AllowSameVersionUpgrades="yes" />
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" AllowSameVersionUpgrades="yes" />
 
     <ui:WixUI Id="WixUI_Minimal" />
-    <WixVariable Id="WixUILicenseRtf" Value="scripts\EULA.rtf" />
+    <WixVariable Id="WixUILicenseRtf" Value="!(loc.LicenseRtf)" />
 
     <MediaTemplate EmbedCab="yes" />
 
@@ -30,8 +31,8 @@
             Id="EGoTouchServiceInstaller"
             Type="ownProcess"
             Name="EGoTouchService"
-            DisplayName="EGoTouch Capacitive Touch Driver (Test)"
-            Description="EGoTouch Capacitive Touch Driver Service - Test Version."
+            DisplayName="!(loc.ServiceDisplayNameTest)"
+            Description="!(loc.ServiceDescriptionTest)"
             Start="auto"           
             Account="LocalSystem"
             ErrorControl="normal" />

--- a/scripts/EULA_zh-CN.rtf
+++ b/scripts/EULA_zh-CN.rtf
@@ -1,0 +1,33 @@
+{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}{\f1\fnil\fcharset134 Microsoft YaHei;}}
+{\*\generator Riched20 10.0.19041}\viewkind4\uc1
+\pard\sa200\sl276\slmult1\f0\fs24\b EGoTouchRev Community Project - End User License Agreement (EULA)\par
+\par
+IMPORTANT NOTICE: PLEASE READ CAREFULLY\b0\par
+\par
+\b 1. NATURE OF THE PROJECT\b0\par
+This software ("EGoTouchRev") is an independent, community-driven, open-source project. It has been developed through clean-room reverse engineering for educational, interoperability, and research purposes only.\par
+\par
+\b 2. NO AFFILIATION\b0\par
+The developers and contributors of this project are NOT affiliated, associated, authorized, endorsed by, or in any way officially connected with the original hardware manufacturers (such as Himax) or any trademark holders associated with the original touch hardware. All product and company names are the registered trademarks of their original owners.\par
+\par
+\b 3. NON-COMMERCIAL USE\b0\par
+This software is provided exclusively for non-commercial, personal use. You may not use this software for any commercial product, monetary gain, or enterprise deployment without acknowledging the reverse-engineered nature and assuming full legal responsibility.\par
+\par
+\b 4. DISCLAIMER OF LIABILITY (USE AT YOUR OWN RISK)\b0\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\par
+\par
+IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS, OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY (INCLUDING BUT NOT LIMITED TO ARISING FROM:\par
+- HARDWARE BRICKING OR DAMAGE\par
+- DATA CORRUPTION\par
+- SYSTEM INSTABILITY OR CRASHES\par
+- POTENTIAL VIOLATIONS OF THIRD-PARTY TERMS OF SERVICE)\par
+\par
+You are installing a proprietary hardware driver alternative. BY USING THIS SOFTWARE, YOU ACKNOWLEDGE THE RISKS INVOLVED AND AGREE THAT YOU ARE USING IT ENTIRELY AT YOUR OWN RISK.\par
+\par
+\b 5. MIT License Applies\b0\par
+Subject to the above disclaimers, the underlying original code written by the community is licensed under the standard MIT License.\par
+\par
+\b \f1\fs24 安装说明:\f0\fs24\b0\par
+\f1\fs24 1. 该驱动与华为的原版驱动HuaweiThpService以及华为电脑管家存在冲突，请在安装和运行本驱动前停止这两个进程，否则可能导致触摸失效或蓝屏。\f0\fs24\par
+\f1\fs24 2. 如遇问题，请在GitHub项目中反馈: https://github.com/EGoTouchRev/EGoTouchRev/issues\f0\fs24\par
+}

--- a/scripts/en-US.wxl
+++ b/scripts/en-US.wxl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WixLocalization Culture="en-US" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Language" Value="1033" />
+  <String Id="ProductName" Value="EGoTouch Controller Software" />
+  <String Id="ProductNameTest" Value="EGoTouch Controller Software (Test Version)" />
+  <String Id="Manufacturer" Value="EGoTouch Team" />
+  <String Id="DowngradeError" Value="A newer version of [ProductName] is already installed." />
+  <String Id="LicenseRtf" Value="scripts\EULA.rtf" />
+  <String Id="ServiceDisplayName" Value="EGoTouch Capacitive Touch Driver" />
+  <String Id="ServiceDescription" Value="EGoTouch Capacitive Touch Driver Service - Manages touch frame acquisition, algorithm processing, and HID injection." />
+  <String Id="ServiceDisplayNameTest" Value="EGoTouch Capacitive Touch Driver (Test)" />
+  <String Id="ServiceDescriptionTest" Value="EGoTouch Capacitive Touch Driver Service - Test Version." />
+</WixLocalization>

--- a/scripts/pack_test_version.bat
+++ b/scripts/pack_test_version.bat
@@ -17,7 +17,7 @@ echo.
 echo [2/3] Preparing MSI Component variables...
 :: WiX v4 build command requires wix.exe
 :: Make sure wix is installed on the user system.
-wix build -ext WixToolset.UI.wixext -arch x64 scripts\EGoTouchTestSetup.wxs -out build\EGoTouchTestSetup.msi
+wix build -ext WixToolset.UI.wixext -arch x64 scripts\EGoTouchTestSetup.wxs -loc scripts\zh-CN.wxl -out build\EGoTouchTestSetup.msi
 if %errorlevel% neq 0 (
     echo [ERROR] WiX build failed.
     exit /b %errorlevel%

--- a/scripts/zh-CN.wxl
+++ b/scripts/zh-CN.wxl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WixLocalization Culture="zh-CN" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Language" Value="2052" />
+  <String Id="ProductName" Value="EGoTouch Controller Software" />
+  <String Id="ProductNameTest" Value="EGoTouch Controller Software (Test Version)" />
+  <String Id="Manufacturer" Value="EGoTouch Team" />
+  <String Id="DowngradeError" Value="已经安装了更高版本的 [ProductName]。" />
+  <String Id="LicenseRtf" Value="scripts\EULA_zh-CN.rtf" />
+  <String Id="ServiceDisplayName" Value="EGoTouch Capacitive Touch Driver" />
+  <String Id="ServiceDescription" Value="EGoTouch 电容触控控制器驱动服务 — 管理触摸屏帧采集、算法处理与 HID 注入。" />
+  <String Id="ServiceDisplayNameTest" Value="EGoTouch Capacitive Touch Driver (Test)" />
+  <String Id="ServiceDescriptionTest" Value="EGoTouch 电容触控控制器驱动服务 — 测试版本。" />
+</WixLocalization>


### PR DESCRIPTION
Resolves the "Failed to Start" error encountered during MSI installation by statically linking the MSVC runtime. It also adds Chinese localization to the WiX installer and includes a localized EULA with user-requested warnings about process conflicts.

---
*PR created automatically by Jules for task [17534436204595732716](https://jules.google.com/task/17534436204595732716) started by @awarson2233*