### PR TITLE
🔒 Fix insecure NULL DACL in Named Pipe Server

### DIFF
--- a/Common/source/IpcPipeServer.cpp
+++ b/Common/source/IpcPipeServer.cpp
@@ -1,5 +1,6 @@
 #include "IpcPipeServer.h"
 #include "Logger.h"
+#include <sddl.h>
 
 namespace Ipc {
 
@@ -27,14 +28,23 @@ void IpcPipeServer::Stop() {
 }
 
 void IpcPipeServer::ServerLoop() {
-    // Build permissive security descriptor for cross-session access
+    // Build secure security descriptor for cross-session access
     // (Service runs as SYSTEM, App runs as user)
-    SECURITY_DESCRIPTOR sd{};
-    InitializeSecurityDescriptor(&sd, SECURITY_DESCRIPTOR_REVISION);
-    SetSecurityDescriptorDacl(&sd, TRUE, nullptr, FALSE);  // NULL DACL = full access
+    // D: (DACL)
+    // (A;;GA;;;SY)  - Allow Full Access to SYSTEM
+    // (A;;GA;;;BA)  - Allow Full Access to Built-in Administrators
+    // (A;;GRGW;;;BU) - Allow Read/Write to Built-in Users
+    LPCWSTR sddl = L"D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;BU)";
+    PSECURITY_DESCRIPTOR pSd = nullptr;
+    if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl, SDDL_REVISION_1, &pSd, nullptr)) {
+        LOG_ERROR("IPC", __func__, "IPC", "Failed to create security descriptor: {}", GetLastError());
+        return;
+    }
+
     SECURITY_ATTRIBUTES sa{};
     sa.nLength = sizeof(sa);
-    sa.lpSecurityDescriptor = &sd;
+    sa.lpSecurityDescriptor = pSd;
     sa.bInheritHandle = FALSE;
 
     while (m_running.load()) {
@@ -83,6 +93,10 @@ void IpcPipeServer::ServerLoop() {
         DisconnectNamedPipe(pipe);
         CloseHandle(pipe);
         LOG_INFO("IPC", __func__, "IPC", "Client disconnected.");
+    }
+
+    if (pSd) {
+        LocalFree(pSd);
     }
 }
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the insecure usage of a NULL DACL (Discretionary Access Control List) in the creation of the `IpcPipeServer` named pipe.

⚠️ **Risk:** A NULL DACL grants full access (read, write, modify, delete) to everyone. Since the service runs as SYSTEM, an attacker or standard user could exploit this to intercept IPC messages, disrupt the service, or potentially escalate privileges.

🛡️ **Solution:** The fix replaces the NULL DACL with an explicit Security Descriptor defined using SDDL (`D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;BU)`). This explicitly grants full control to SYSTEM and Built-in Administrators, and read/write access to Built-in Users, restricting the attack surface and preventing unauthorized access. Memory for the allocated security descriptor is also safely managed and released with `LocalFree`.

---
*PR created automatically by Jules for task [6515309298116657713](https://jules.google.com/task/6515309298116657713) started by @awarson2233*