### PR TITLE
🔒 Fix insecure NULL DACL for System State Monitor Events

### DIFF
--- a/EGoTouchService/Host/SystemStateMonitor.cpp
+++ b/EGoTouchService/Host/SystemStateMonitor.cpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <utility>
+#include <sddl.h>
 
 namespace Host {
 
@@ -19,31 +20,38 @@ constexpr std::array<const wchar_t*, SystemStateMonitor::kEventCount> kNamedEven
     L"Global\\PBT_APMRESUMEAUTOMATIC",
 };
 
-SECURITY_ATTRIBUTES BuildPermissiveGlobalSa(SECURITY_DESCRIPTOR& sd) {
-    SECURITY_ATTRIBUTES sa{};
-    sa.nLength = sizeof(sa);
-    sa.bInheritHandle = FALSE;
-    sa.lpSecurityDescriptor = nullptr;
-
-    if (InitializeSecurityDescriptor(&sd, SECURITY_DESCRIPTOR_REVISION) != 0 &&
-        SetSecurityDescriptorDacl(&sd, TRUE, nullptr, FALSE) != 0) {
-        sa.lpSecurityDescriptor = &sd;
-    }
-
-    return sa;
-}
-
 HANDLE OpenOrCreateNamedEvent(const wchar_t* name) {
     HANDLE handle = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, name);
     if (handle != nullptr) {
         return handle;
     }
 
-    SECURITY_DESCRIPTOR sd{};
-    SECURITY_ATTRIBUTES sa = BuildPermissiveGlobalSa(sd);
-    LPSECURITY_ATTRIBUTES sa_ptr = sa.lpSecurityDescriptor != nullptr ? &sa : nullptr;
+    SECURITY_ATTRIBUTES sa{};
+    sa.nLength = sizeof(sa);
+    sa.bInheritHandle = FALSE;
+    sa.lpSecurityDescriptor = nullptr;
 
-    return CreateEventW(sa_ptr, TRUE, FALSE, name);
+    // Secure SDDL:
+    // D: DACL
+    // (A;;GA;;;SY) -> Allow Generic All for SYSTEM
+    // (A;;GA;;;BA) -> Allow Generic All for Built-in Administrators
+    // (A;;GRGW;;;BU) -> Allow Generic Read/Write for Built-in Users
+    if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            L"D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;BU)",
+            SDDL_REVISION_1,
+            &sa.lpSecurityDescriptor,
+            nullptr)) {
+        // Fallback to default security descriptor if conversion fails
+        sa.lpSecurityDescriptor = nullptr;
+    }
+
+    HANDLE new_handle = CreateEventW(sa.lpSecurityDescriptor ? &sa : nullptr, TRUE, FALSE, name);
+
+    if (sa.lpSecurityDescriptor != nullptr) {
+        LocalFree(sa.lpSecurityDescriptor);
+    }
+
+    return new_handle;
 }
 
 } // namespace


### PR DESCRIPTION
🎯 **What:** Fixed an insecure NULL DACL vulnerability in System State Monitor Events.
⚠️ **Risk:** A NULL DACL permits full access (Generic All) to everyone. An unprivileged user or malicious process could spoof or hijack these global events, potentially tricking the EGoTouchService into falsely believing power/display state changes occurred.
🛡️ **Solution:** Removed `BuildPermissiveGlobalSa` and refactored `OpenOrCreateNamedEvent` to apply a secure SDDL string (`D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;BU)`), explicitly restricting full control to SYSTEM and Administrators while allowing built-in users appropriate access. Memory cleanup for the security descriptor is securely handled via `LocalFree`.

---
*PR created automatically by Jules for task [324809408909280827](https://jules.google.com/task/324809408909280827) started by @awarson2233*