### PR TITLE
🔒 Fix unchecked sscanf_s return values in BtMcuTestTool

### DIFF
--- a/Tools/BtMcuTestTool/BtMcuTestTool.cpp
+++ b/Tools/BtMcuTestTool/BtMcuTestTool.cpp
@@ -577,19 +577,19 @@ int main(int, char**)
         ImGui::InputText("Payload (Hex Space Separated)", customPayloadBuf, sizeof(customPayloadBuf));
         if (ImGui::Button("Send Custom")) {
             uint32_t cmdId = 0;
-            sscanf_s(customCmdBuf, "%x", &cmdId);
-            
-            std::vector<uint8_t> payload;
-            char* next_token = nullptr;
-            char* token = strtok_s(customPayloadBuf, " ", &next_token);
-            while (token != nullptr) {
-                uint32_t val = 0;
-                if (sscanf_s(token, "%x", &val) == 1) {
-                    payload.push_back(static_cast<uint8_t>(val));
+            if (sscanf_s(customCmdBuf, "%x", &cmdId) == 1) {
+                std::vector<uint8_t> payload;
+                char* next_token = nullptr;
+                char* token = strtok_s(customPayloadBuf, " ", &next_token);
+                while (token != nullptr) {
+                    uint32_t val = 0;
+                    if (sscanf_s(token, "%x", &val) == 1) {
+                        payload.push_back(static_cast<uint8_t>(val));
+                    }
+                    token = strtok_s(nullptr, " ", &next_token);
                 }
-                token = strtok_s(nullptr, " ", &next_token);
+                SendPacket(static_cast<uint16_t>(cmdId), payload);
             }
-            SendPacket(static_cast<uint16_t>(cmdId), payload);
         }
 
         ImGui::Separator();
@@ -611,8 +611,9 @@ int main(int, char**)
         ImGui::SameLine();
         if (ImGui::Button("Send ACK")) {
             uint32_t ackVal = 0;
-            sscanf_s(ackBuf, "%x", &ackVal);
-            SendPacket(0x8001, {static_cast<uint8_t>(ackVal)});
+            if (sscanf_s(ackBuf, "%x", &ackVal) == 1) {
+                SendPacket(0x8001, {static_cast<uint8_t>(ackVal)});
+            }
         }
 
         ImGui::Separator();


### PR DESCRIPTION
🎯 **What:** Fixed unchecked `sscanf_s` return values in `Tools/BtMcuTestTool/BtMcuTestTool.cpp`. The code was relying on the value returned into out variables (`ackVal` and `cmdId`) without checking if the conversion was actually successful.
⚠️ **Risk:** If a user or external script supplies malformed input that fails parsing, the variables `ackVal` and `cmdId` remain uninitialized (or their default initialized values of 0), leading the application to send corrupted packets or executing unintended commands, resulting in memory safety issues or undefined behavior.
🛡️ **Solution:** Wrapped the parsing logic with an `if (sscanf_s(...) == 1)` check to ensure the payload assembly and transmission only proceed if the parsing returns precisely 1 successfully parsed item. 

*(Note: Test execution could not be performed natively since the codebase heavily targets Windows on ARM64 and relies on `<windows.h>` missing on the current development environment. Changes are syntax-safe standard C++)*

---
*PR created automatically by Jules for task [16511604733541484718](https://jules.google.com/task/16511604733541484718) started by @awarson2233*