### PR TITLE
🧪 Add Logger init error path test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(EGoTouchRev VERSION 0.1.0 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+include(CTest)
+enable_testing()
+
 # --- Platform compatibility ---
 # Prevent Windows.h from defining min/max macros that conflict with std::min/std::max
 # Suppress MSVC CRT deprecation warnings (e.g. localtime -> localtime_s)
@@ -208,6 +211,14 @@ if (EGO_BUILD_TESTS)
         Tools/tests/RawdataBenchmarkTest.cpp
     )
     target_link_libraries(EngineRawdataBenchmarkTest PRIVATE Engine Common)
+
+    add_executable(CommonLoggerTest
+        Tools/tests/LoggerTest.cpp
+    )
+    target_include_directories(CommonLoggerTest PRIVATE "${COMMON_ROOT}/include")
+    target_link_libraries(CommonLoggerTest PRIVATE Common)
+
+    add_test(NAME CommonLoggerTest COMMAND CommonLoggerTest)
 endif()
 
 

--- a/Tools/tests/LoggerTest.cpp
+++ b/Tools/tests/LoggerTest.cpp
@@ -1,0 +1,51 @@
+#include "Logger.h"
+#include <filesystem>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+int main() {
+    // We want to test the error path in Logger::Init
+    // Specifically, if we provide a path that cannot be created,
+    // it should output to std::cerr and not throw an unhandled exception or crash.
+
+    // First, let's create a file so that create_directories on that path fails
+    std::filesystem::path invalid_dir = "test_invalid_dir_file.txt";
+
+    std::ofstream out(invalid_dir);
+    out << "This is a file, not a dir";
+    out.close();
+
+    // We need to capture std::cerr to verify the error message
+    std::stringstream buffer;
+    std::streambuf* old_cerr = std::cerr.rdbuf(buffer.rdbuf());
+
+    // This should fail to create the directory because a file already exists with that name.
+    Common::Logger::Init("TestLogger", invalid_dir);
+
+    // Restore std::cerr
+    std::cerr.rdbuf(old_cerr);
+
+    std::string err_output = buffer.str();
+
+    // Check if the expected error message is in the captured output
+    if (err_output.find("Failed to create log directory") == std::string::npos) {
+        std::cerr << "[TEST] Failed: Expected error message not found in std::cerr. Output was: " << err_output << std::endl;
+        std::filesystem::remove(invalid_dir);
+        return 1;
+    }
+
+    // Verify that the logger was NOT initialized.
+    if (Common::Logger::Get() != nullptr) {
+        std::cerr << "[TEST] Failed: Logger should not be initialized on error." << std::endl;
+        std::filesystem::remove(invalid_dir);
+        Common::Logger::Shutdown();
+        return 2;
+    }
+
+    // Cleanup
+    std::filesystem::remove(invalid_dir);
+
+    std::cout << "[TEST] Logger init error path test passed.\n";
+    return 0;
+}


### PR DESCRIPTION
🎯 **What:** The testing gap in `Logger::Init` (handling of failed directory creation) has been addressed by creating a dedicated test case that verifies the error reporting and early-return logic.
📊 **Coverage:** The test creates a dummy file at the log path, simulating a scenario where `std::filesystem::create_directories` throws/returns an error code. It captures `std::cerr` to confirm the correct error message is printed and verifies that `Common::Logger::Get()` remains null. 
✨ **Result:** Test coverage improved for common utility error paths. The test is integrated into CTest and builds seamlessly with the existing test infrastructure.

---
*PR created automatically by Jules for task [11734157744392448090](https://jules.google.com/task/11734157744392448090) started by @awarson2233*