### PR TITLE
🔒 Fix unchecked sscanf_s parsing in BtMcuTestTool

### DIFF
--- a/Tools/BtMcuTestTool/BtMcuTestTool.cpp
+++ b/Tools/BtMcuTestTool/BtMcuTestTool.cpp
@@ -126,7 +126,9 @@ static std::atomic<uint8_t> g_pressFreq1{0}, g_pressFreq2{0};
 static std::atomic<uint8_t> g_pressReportType{0};
 
 #include <setupapi.h>
+extern "C" {
 #include <hidsdi.h>
+}
 #include <optional>
 #include <algorithm>
 #include <cwctype>
@@ -577,19 +579,19 @@ int main(int, char**)
         ImGui::InputText("Payload (Hex Space Separated)", customPayloadBuf, sizeof(customPayloadBuf));
         if (ImGui::Button("Send Custom")) {
             uint32_t cmdId = 0;
-            sscanf_s(customCmdBuf, "%x", &cmdId);
-            
-            std::vector<uint8_t> payload;
-            char* next_token = nullptr;
-            char* token = strtok_s(customPayloadBuf, " ", &next_token);
-            while (token != nullptr) {
-                uint32_t val = 0;
-                if (sscanf_s(token, "%x", &val) == 1) {
-                    payload.push_back(static_cast<uint8_t>(val));
+            if (sscanf_s(customCmdBuf, "%x", &cmdId) == 1) {
+                std::vector<uint8_t> payload;
+                char* next_token = nullptr;
+                char* token = strtok_s(customPayloadBuf, " ", &next_token);
+                while (token != nullptr) {
+                    uint32_t val = 0;
+                    if (sscanf_s(token, "%x", &val) == 1) {
+                        payload.push_back(static_cast<uint8_t>(val));
+                    }
+                    token = strtok_s(nullptr, " ", &next_token);
                 }
-                token = strtok_s(nullptr, " ", &next_token);
+                SendPacket(static_cast<uint16_t>(cmdId), payload);
             }
-            SendPacket(static_cast<uint16_t>(cmdId), payload);
         }
 
         ImGui::Separator();
@@ -611,8 +613,9 @@ int main(int, char**)
         ImGui::SameLine();
         if (ImGui::Button("Send ACK")) {
             uint32_t ackVal = 0;
-            sscanf_s(ackBuf, "%x", &ackVal);
-            SendPacket(0x8001, {static_cast<uint8_t>(ackVal)});
+            if (sscanf_s(ackBuf, "%x", &ackVal) == 1) {
+                SendPacket(0x8001, {static_cast<uint8_t>(ackVal)});
+            }
         }
 
         ImGui::Separator();


### PR DESCRIPTION
### 🎯 What
Fixed two instances of unchecked `sscanf_s` return values in `Tools/BtMcuTestTool/BtMcuTestTool.cpp`.
1. Line 580: When parsing a custom Command ID hex input (`customCmdBuf`).
2. Line 614: When parsing a custom Manual ACK hex input (`ackBuf`).

### ⚠️ Risk
If a user left the text inputs blank or typed invalid hexadecimal characters, `sscanf_s` would fail to parse a number and return `0`, leaving `cmdId` and `ackVal` uninitialized or set to `0`. The code would then proceed to send a packet over the USB/Bluetooth transport using this garbage/default data.

While this tool is meant for local diagnostics and testing, sending garbage packets to the MCU might trigger unexpected states, panic the device, or theoretically act as a gadget in more complex exploitation chains if the input could be controlled via an unexpected source. In a diagnostic tool, predictable failure and bounds checking is critical.

### 🛡️ Solution
Wrapped the execution branches around `if (sscanf_s(...) == 1)`. If the parsing fails, the uninitialized variable is not used, and no malformed packet is dispatched to the device.

---
*PR created automatically by Jules for task [10208762910763289236](https://jules.google.com/task/10208762910763289236) started by @awarson2233*