### PR TITLE
🧪 Add SharedFrameBuffer tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,14 @@ if (EGO_BUILD_TESTS)
     target_link_libraries(CommonLoggerTest PRIVATE Common)
 
     add_test(NAME CommonLoggerTest COMMAND CommonLoggerTest)
+
+    add_executable(CommonSharedFrameBufferTest
+        Tools/tests/SharedFrameBufferTest.cpp
+    )
+    target_include_directories(CommonSharedFrameBufferTest PRIVATE "${COMMON_ROOT}/include" "${ENGINE_ROOT}")
+    target_link_libraries(CommonSharedFrameBufferTest PRIVATE Common Engine)
+
+    add_test(NAME CommonSharedFrameBufferTest COMMAND CommonSharedFrameBufferTest)
 endif()
 
 

--- a/EGoTouchService/Engine/TouchSolver/CoordinateFilter.cpp
+++ b/EGoTouchService/Engine/TouchSolver/CoordinateFilter.cpp
@@ -1,6 +1,7 @@
 #include "CoordinateFilter.h"
 #include <cmath>
 #include <vector>
+#include <algorithm>
 
 namespace Engine {
 

--- a/Tools/tests/SharedFrameBufferTest.cpp
+++ b/Tools/tests/SharedFrameBufferTest.cpp
@@ -1,0 +1,51 @@
+#include "SharedFrameBuffer.h"
+#include <iostream>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+int main() {
+    std::cout << "[TEST] Starting SharedFrameBuffer test...\n";
+
+    Ipc::SharedFrameWriter writer;
+
+    // Test successful creation
+    const wchar_t* valid_name = L"Local\\EGoTouchSharedFrameTest";
+    if (!writer.Create(valid_name)) {
+        std::cerr << "[TEST] Failed: Could not create SharedFrameWriter with valid name." << std::endl;
+        return 1;
+    }
+
+    if (!writer.IsOpen()) {
+        std::cerr << "[TEST] Failed: Writer should report IsOpen() == true after successful creation." << std::endl;
+        return 2;
+    }
+
+    // Since we successfully created it, close it.
+    writer.Close();
+
+    if (writer.IsOpen()) {
+        std::cerr << "[TEST] Failed: Writer should report IsOpen() == false after Close()." << std::endl;
+        return 3;
+    }
+
+    // Try to create with an invalid name (e.g. empty string or nullptr to trigger failure if possible, or using an invalid character in name)
+    // Note: For CreateFileMappingW, if lpName is an invalid string, it might fail. Let's pass a known bad character or something that causes ERROR_INVALID_NAME.
+    // L"\\" is an invalid name because a name cannot contain backslashes except for the "Global\\" or "Local\\" prefixes.
+    const wchar_t* invalid_name = L"Invalid\\Name/With*Bad?Chars";
+    if (writer.Create(invalid_name)) {
+        std::cerr << "[TEST] Failed: Create should fail with an invalid name." << std::endl;
+        writer.Close();
+        return 4;
+    }
+
+    if (writer.IsOpen()) {
+        std::cerr << "[TEST] Failed: Writer should not be open after a failed Create()." << std::endl;
+        return 5;
+    }
+
+    std::cout << "[TEST] SharedFrameBuffer test passed.\n";
+    return 0;
+}


### PR DESCRIPTION
🎯 **What:** The untested public `SharedFrameWriter::Create` API in `SharedFrameBuffer.cpp` needed test coverage.
📊 **Coverage:** The new test covers successful creation of the cross-process memory mapping (`Create` and `IsOpen`), handles closing correctly, and checks the error condition when an invalid name is passed.
✨ **Result:** Enhanced test coverage for the IPC Shared Frame mapping.

---
*PR created automatically by Jules for task [3383789710773583349](https://jules.google.com/task/3383789710773583349) started by @awarson2233*