### PR TITLE
feat: implement BT MCU frequency synchronization pipeline

### DIFF
--- a/EGoTouchService/Device/btmcu/BtHidChannel.cpp
+++ b/EGoTouchService/Device/btmcu/BtHidChannel.cpp
@@ -36,15 +36,22 @@ void BtHidChannel::WorkerFunc() {
     while (m_running.load()) {
         auto path = FindDevicePath();
         if (path) {
+            // Log the found device path
+            std::string pathA(path->begin(), path->end());
+            LOG_INFO(ChannelName(), "WorkerFunc", "MCU",
+                     "[Thread] Found device: {}", pathA);
             auto res = m_transport->Open(*path);
             if (res) {
                 LOG_INFO(ChannelName(), "WorkerFunc", "MCU",
-                         "[Thread] Channel opened.");
+                         "[Thread] Channel opened successfully.");
                 break;
             }
+            LOG_WARN(ChannelName(), "WorkerFunc", "MCU",
+                     "[Thread] Open failed for device, retry...");
+        } else {
+            LOG_WARN(ChannelName(), "WorkerFunc", "MCU",
+                     "[Thread] Device not found, retry in 2s...");
         }
-        LOG_WARN(ChannelName(), "WorkerFunc", "MCU",
-                 "[Thread] Device not found, retry in 2s...");
         std::this_thread::sleep_for(std::chrono::seconds(2));
     }
 

--- a/EGoTouchService/Device/btmcu/PenUsbTypes.h
+++ b/EGoTouchService/Device/btmcu/PenUsbTypes.h
@@ -42,13 +42,13 @@ enum class PenSessionState : uint8_t {
 };
 
 struct PenUsbHeader {
-    uint8_t reportId = 0x07;
-    uint8_t direction = 0x00;
-    uint8_t protocol = 0x02;
-    uint8_t reserved0 = 0x00;
-    uint16_t commandId = 0x0000;
-    uint8_t transportTag = 0x11;
-    uint8_t option = 0x00;
+    uint8_t reportId     = 0x07;  // byte[0]: HID report type (always 0x07)
+    uint8_t hasPayload   = 0x00;  // byte[1]: 0x00=no payload, 0x01=has payload
+    uint8_t protocol     = 0x02;  // byte[2]: sub-protocol (always 0x02)
+    uint8_t reserved0    = 0x00;  // byte[3]: reserved
+    uint16_t commandId   = 0x0000;// byte[4,5]: command ID (little-endian)
+    uint8_t transportTag = 0x11;  // byte[6]: MCU transport marker (forced by SendPacket)
+    uint8_t payloadTag   = 0x00;  // byte[7]: 0x00=no payload, 0x20=has payload
 };
 
 struct PenUsbPacket {

--- a/EGoTouchService/Device/common/StylusState.h
+++ b/EGoTouchService/Device/common/StylusState.h
@@ -1,19 +1,14 @@
 #pragma once
 #include <cstdint>
 
-// ── 手写笔频率命令对 ─────────────────────────────────────────────────────────
-// 每支笔在芯片频率表中有两个频点命令（由 set_stylus_id 时绑定）
-struct StylusFreqPair {
-    uint16_t freq0_cmd = 0;   // 频点0命令（标准频率，默认扫描）
-    uint16_t freq1_cmd = 0;   // 频点1命令（240Hz 高频扫描）
-};
-
 // ── 用户态驱动侧手写笔状态 ────────────────────────────────────────────────────
-// 由 StylusFreqManager 维护，供 ProcessStylusStatus 使用
+// 由 AfeController 维护，供 ProcessStylusStatus 使用
+//
+// 频率表绑定到 TPIC panel (OTP ID)，不绑定到笔。
+// 参见 HimaxAfe.cpp 中的 kTpicFreqTable[]。
 struct StylusState {
     bool           connected        = false; // 手写笔已通过 BTMCU 连接
     uint8_t        pen_id           = 0;     // 注册的笔 ID（0-3 主表，5=默认）
-    StylusFreqPair freqPair;                 // 当前笔的频率命令对
     uint8_t        freqIdx          = 0;     // 当前使用的频点索引（0 或 1）
     uint8_t        switchPolicy     = 0;     // 0=禁用自动切换, 2=启用噪声触发切换
     uint8_t        switchTargetIdx  = 0;     // 目标频点（噪声判断后写入）

--- a/EGoTouchService/Device/himax/HimaxAfe.cpp
+++ b/EGoTouchService/Device/himax/HimaxAfe.cpp
@@ -24,15 +24,14 @@ const char* AfeCommandToString(AFE_Command cmd) {
     }
 }
 
-/// 默认频率命令表（4 条目 + 1 默认笔 ID=5）
-/// 来源：Ghidra 逆向 himax_thp_drv.dll DAT_18016dc80
-static constexpr struct { uint8_t id; uint16_t f0; uint16_t f1; } kFreqTable[] = {
-    {0, 0x00A1, 0x0018},   // 笔 0
-    {1, 0x00A2, 0x0019},   // 笔 1
-    {2, 0x00A3, 0x001A},   // 笔 2
-    {3, 0x00A4, 0x001B},   // 笔 3
-    {5, 0x00A1, 0x0018},   // 默认笔 "CD54" (ID=5)
+/// TPIC 频率命令表（panel 级别，由 OTP project ID 决定）
+/// 来源：Ghidra 逆向 thp_afe_open_project → DAT_180195380 / DAT_180195384
+/// freq_idx=0 → 0x4B (75), freq_idx=1 → 0x71 (113)
+static constexpr uint8_t kTpicFreqTable[] = {
+    0x4B,   // freq[0] — 默认频点
+    0x71,   // freq[1] — 备用频点
 };
+static constexpr uint8_t kMaxFreqIdx = static_cast<uint8_t>(std::size(kTpicFreqTable));
 
 } // anonymous namespace
 
@@ -144,7 +143,12 @@ ChipResult<> AfeController::ForceToFreqPoint(uint8_t freq_idx) {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Entering with freq_idx={}", static_cast<unsigned>(freq_idx));
+    if (freq_idx >= kMaxFreqIdx) {
+        LOG_WARN("HimaxAFE", __func__, m_chip.GetStateStr(), "freq_idx={} out of range (max={})", static_cast<unsigned>(freq_idx), kMaxFreqIdx);
+        return std::unexpected(ChipError::InvalidOperation);
+    }
+
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "freq_idx={} → tpicFreq=0x{:02X}", static_cast<unsigned>(freq_idx), kTpicFreqTable[freq_idx]);
     return HimaxProtocol::send_command(m_chip.GetMasterDevice(), 0x0c, freq_idx, m_chip.GetCurrentSlot());
 }
 
@@ -154,6 +158,11 @@ ChipResult<> AfeController::ForceToScanRate(uint8_t rate_idx) {
 
     LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Entering with rate_idx={}", static_cast<unsigned>(rate_idx));
     return HimaxProtocol::send_command(m_chip.GetMasterDevice(), 0x0e, rate_idx, m_chip.GetCurrentSlot());
+}
+
+uint8_t AfeController::GetTpicFreq(uint8_t idx) const {
+    if (idx >= kMaxFreqIdx) return kTpicFreqTable[0];  // fallback to default
+    return kTpicFreqTable[idx];
 }
 
 // ── 手写笔生命周期 ──────────────────────────────────────────────────────────
@@ -180,21 +189,13 @@ ChipResult<> AfeController::SetStylusId(uint8_t pen_id) {
     if (m_chip.GetConnectionState() != ConnectionState::Connected)
         return std::unexpected(ChipError::InvalidOperation);
 
-    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "0x73 pen_type={} → 查频率表绑定 FreqPair", static_cast<unsigned>(pen_id));
+    m_stylus.pen_id = pen_id;
 
-    StylusFreqPair pair{0x00A1, 0x0018};  // 默认值（ID=5）
-    for (auto& e : kFreqTable) {
-        if (e.id == pen_id) {
-            pair.freq0_cmd = e.f0;
-            pair.freq1_cmd = e.f1;
-            break;
-        }
-    }
-
-    m_stylus.pen_id   = pen_id;
-    m_stylus.freqPair = pair;
-
-    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "Stylus freq pair bound: freq0=0x{:04X}, freq1=0x{:04X}", pair.freq0_cmd, pair.freq1_cmd);
+    // 频率表绑定到 panel (kTpicFreqTable)，不与笔绑定。
+    // 这里只记录笔 ID，实际频率由 kTpicFreqTable[freqIdx] 决定。
+    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(),
+             "pen_id={}, tpicFreq[0]=0x{:02X}, tpicFreq[1]=0x{:02X}",
+             static_cast<unsigned>(pen_id), kTpicFreqTable[0], kTpicFreqTable[1]);
     return {};
 }
 
@@ -303,12 +304,19 @@ bool AfeController::ProcessStylusStatus() {
             } else {
                 uint32_t mismatchAge = m_stylus.frameCounter - m_stylus.btMismatchFrame;
                 if (mismatchAge > kBtMismatchDebounce) {
-                    uint8_t targetIdx = (m_stylus.btFreq1 == m_stylus.freqPair.freq1_cmd) ? 1 : 0;
+                    // 根据 BT 报告的频率反查 kTpicFreqTable，确定目标 idx
+                    uint8_t targetIdx = 0;
+                    for (uint8_t i = 0; i < kMaxFreqIdx; ++i) {
+                        if (kTpicFreqTable[i] == m_stylus.btFreq1) {
+                            targetIdx = i;
+                            break;
+                        }
+                    }
                     m_stylus.switchTargetIdx  = targetIdx;
                     m_stylus.switchReqPending = true;
                     m_stylus.switchReqFrame   = m_stylus.frameCounter;
                     m_stylus.btMismatchActive = false;
-                    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "BT-TP mismatch >30ms: tp={} bt={} → ForceToFreqPoint({})", tpFreq1, m_stylus.btFreq1, targetIdx);
+                    LOG_INFO("HimaxAFE", __func__, m_chip.GetStateStr(), "BT-TP mismatch >30ms: tp=0x{:02X} bt=0x{:02X} → ForceToFreqPoint({})", tpFreq1, m_stylus.btFreq1, targetIdx);
                     return true;
                 }
             }

--- a/EGoTouchService/Device/himax/HimaxAfe.h
+++ b/EGoTouchService/Device/himax/HimaxAfe.h
@@ -32,6 +32,10 @@ public:
     ChipResult<> ForceToFreqPoint(uint8_t freq_idx);
     ChipResult<> ForceToScanRate(uint8_t rate_idx);
 
+    /// 查询 TPIC 频率表中指定索引的频率命令码
+    /// 用于 BT ScanMode 命令构造
+    uint8_t GetTpicFreq(uint8_t idx) const;
+
     // ── 手写笔生命周期管理 ─────────────────────────────────────
     ChipResult<> InitStylus(uint8_t pen_id = 5);
     ChipResult<> SetStylusId(uint8_t pen_id);

--- a/EGoTouchService/Device/himax/HimaxChip.cpp
+++ b/EGoTouchService/Device/himax/HimaxChip.cpp
@@ -878,10 +878,8 @@ ChipResult<> Chip::GetFrame(void) {
     bool stylusNow = isStylusDetected();
     if (stylusNow && !m_stylusActive) {
         m_stylusActive = true;
-        LOG_INFO("HimaxChip", __func__, GetStateStr(), "Stylus detected in frame data → 2:1 interleave ON (slave 240Hz)");
     } else if (!stylusNow && m_stylusActive) {
         m_stylusActive = false;
-        LOG_INFO("HimaxChip", __func__, GetStateStr(), "Stylus lost in frame data → 2:1 interleave OFF (slave 120Hz)");
     }
 
     // ── 零帧计数 & idle 自动进入 ─────────────────────────────

--- a/EGoTouchService/Device/penevt/PenEventBridge.cpp
+++ b/EGoTouchService/Device/penevt/PenEventBridge.cpp
@@ -6,6 +6,9 @@
 #include <hidsdi.h>
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #pragma comment(lib, "setupapi.lib")
 #pragma comment(lib, "hid.lib")
@@ -54,6 +57,108 @@ std::optional<std::wstring> PenEventBridge::FindDevicePath() {
     return result;
 }
 
+// ── SetScanMode — BT 笔切频命令 ───────────────────────────────────────────
+//
+// 原厂调用链:
+//   ApDaemon::SetScanMode → 构造 IPC {type=1, code=3, "freq1,freq2,mode"}
+//     → THP_Service::BtPen_HandleInitParamEvent → 解码 ASCII → binary
+//       → BtPen_SendPacket(header, binary_payload, 0x20)
+//
+// 我们直接操作 col00 USB 设备，跳过 THP_Service 的解码层，
+// 因此必须自行实现 HandleInitParamEvent 的 type-3 编码。
+//
+// Header (汇编验证: THP_Service.dll @ 0x18000fe0a-0x18000fe1d):
+//   MOV byte ptr [RSP+0x38], 0x07      → byte[0] = 0x07
+//   MOV word ptr [RSP+0x39], 0x0201    → byte[1] = 0x01, byte[2] = 0x02
+//   MOV word ptr [RSP+0x3c], 0x7D01    → byte[4] = 0x01, byte[5] = 0x7D
+//   MOV byte ptr [RSP+0x3f], 0x20      → byte[7] = 0x20
+//   (byte[6] 由 BtPen_SendPacket 强制覆写为 0x11)
+//
+// Payload: 32-byte binary，由 type-3 解码器从 ASCII 十进制字符串转换而来
+
+bool PenEventBridge::SendScanMode(uint8_t freq1, uint8_t freq2, uint8_t mode) {
+    if (!IsTransportOpen()) {
+        LOG_WARN("PenEvent", __func__, "MCU", "Transport not open, cannot send SetScanMode.");
+        return false;
+    }
+
+    // ── Type-3 编码 (完整版, 支持 len=1/2/3/4) ───────────────────────────
+    // HandleInitParamEvent 对每个 comma-separated token 的解码逻辑:
+    //   len=1: 1 byte  → strtol("0x" + [0])
+    //   len=2: 2 bytes → strtol("0x" + [1]),       strtol("0x" + [0])
+    //   len=3: 2 bytes → strtol("0x" + [1] + [2]), strtol("0x" + [0])
+    //   len=4: 2 bytes → strtol("0x" + [2] + [3]), strtol("0x" + [0] + [1])
+    auto encodeType3Token = [](const char* hex_str, uint8_t* out) -> int {
+        int n = static_cast<int>(strlen(hex_str));
+
+        if (n <= 1) {
+            char h[4] = {'0', 'x', hex_str[0], '\0'};
+            out[0] = static_cast<uint8_t>(strtol(h, nullptr, 0));
+            return 1;
+        }
+        if (n == 2) {
+            // high byte: "0x" + [1]
+            char ha[4] = {'0', 'x', hex_str[1], '\0'};
+            out[0] = static_cast<uint8_t>(strtol(ha, nullptr, 0));
+            // low byte: "0x" + [0]
+            char hb[4] = {'0', 'x', hex_str[0], '\0'};
+            out[1] = static_cast<uint8_t>(strtol(hb, nullptr, 0));
+            return 2;
+        }
+        if (n == 3) {
+            // high byte: "0x" + [1][2]
+            char ha[5] = {'0', 'x', hex_str[1], hex_str[2], '\0'};
+            out[0] = static_cast<uint8_t>(strtol(ha, nullptr, 0));
+            // low byte: "0x" + [0]
+            char hb[4] = {'0', 'x', hex_str[0], '\0'};
+            out[1] = static_cast<uint8_t>(strtol(hb, nullptr, 0));
+            return 2;
+        }
+        // len=4
+        // high byte: "0x" + [2][3]
+        char ha[5] = {'0', 'x', hex_str[2], hex_str[3], '\0'};
+        out[0] = static_cast<uint8_t>(strtol(ha, nullptr, 0));
+        // low byte: "0x" + [0][1]
+        char hb[5] = {'0', 'x', hex_str[0], hex_str[1], '\0'};
+        out[1] = static_cast<uint8_t>(strtol(hb, nullptr, 0));
+        return 2;
+    };
+
+    // 将 uint8_t freq 值转为十进制字符串再编码
+    char s_freq1[8], s_freq2[8], s_mode[8];
+    snprintf(s_freq1, sizeof(s_freq1), "%u", freq1);
+    snprintf(s_freq2, sizeof(s_freq2), "%u", freq2);
+    snprintf(s_mode,  sizeof(s_mode),  "%u", mode ? 3u : 0u);
+
+    uint8_t payload[0x20] = {};  // 32-byte binary payload (zero-init)
+    int off = 0;
+    off += encodeType3Token(s_freq1, payload + off);
+    off += encodeType3Token(s_freq2, payload + off);
+    off += encodeType3Token(s_mode,  payload + off);
+    (void)off;  // 实际总字节数
+
+    // ── 构建 USB 报文: 8-byte header + 32-byte binary payload ────────────
+    std::vector<uint8_t> pkt(8 + 0x20, 0);
+    pkt[0] = 0x07;   // report type
+    pkt[1] = 0x01;   // fixed (payload-present flag)
+    pkt[2] = 0x02;   // sub-group
+    pkt[3] = 0x00;
+    pkt[4] = 0x01;   // cmd_id low  (0x7D01)
+    pkt[5] = 0x7D;   // cmd_id high (0x7D01)
+    pkt[6] = 0x11;   // MCU protocol marker
+    pkt[7] = 0x20;   // payload tag (0x20 for payload-present commands)
+    std::copy(payload, payload + 0x20, pkt.begin() + 8);
+
+    SendRawPacket(pkt);
+    LOG_INFO("PenEvent", __func__, "MCU",
+             "SetScanMode sent: freq1=0x{:02X}, freq2=0x{:02X}, mode={}"
+             " → payload=[{:02X} {:02X} {:02X} {:02X} {:02X} {:02X}]",
+             freq1, freq2, mode,
+             payload[0], payload[1], payload[2],
+             payload[3], payload[4], payload[5]);
+    return true;
+}
+
 // ── 协议辅助 ───────────────────────────────────────────────────────────────
 int PenEventBridge::GetAckCode(uint8_t eventCode) {
     switch (eventCode) {
@@ -72,18 +177,22 @@ void PenEventBridge::SendRawPacket(const std::vector<uint8_t>& pkt) {
 }
 
 void PenEventBridge::SendAck(uint8_t ackCode) {
+    // Header 验证: THP_Service BtPen_SendEventAck @ 0x180011d9d-0x180011dc3
+    //   MOV byte [RSP+0x20], 0x07    MOV word [RSP+0x21], 0x0201
+    //   MOV word [RSP+0x24], 0x8001  MOV byte [RSP+0x27], 0x20
     const std::vector<uint8_t> pkt = {
         0x07, 0x01, 0x02, 0x00,
-        0x01, 0x80, 0x11, 0x00, ackCode
+        0x01, 0x80, 0x11, 0x20, ackCode
     };
     SendRawPacket(pkt);
     LOG_INFO("PenEvent", __func__, "MCU", "ACK sent: 0x{:02X}", ackCode);
 }
 
 void PenEventBridge::SendInitParamEcho(const uint8_t* data, size_t len) {
+    // Header 与 HandleInitParamEvent 相同: cmd_id=0x7D01
     size_t payloadLen = std::min(len, size_t(0x20));
     std::vector<uint8_t> pkt(8 + payloadLen, 0);
-    pkt[0] = 0x07; pkt[1] = 0x20; pkt[2] = 0x01; pkt[3] = 0x00;
+    pkt[0] = 0x07; pkt[1] = 0x01; pkt[2] = 0x02; pkt[3] = 0x00;
     pkt[4] = 0x01; pkt[5] = 0x7D;
     pkt[6] = 0x11; pkt[7] = 0x20;
     std::copy(data, data + payloadLen, pkt.begin() + 8);
@@ -97,7 +206,20 @@ void PenEventBridge::OnConnected() {
 }
 
 void PenEventBridge::OnPacketReceived(const std::vector<uint8_t>& packet) {
-    if (packet.size() < 7) return;
+    if (packet.size() < 8) return;
+
+    // ── 诊断: 完整报文 hex dump (前 16 字节) ──
+    {
+        std::string hexDump;
+        size_t dumpLen = std::min(packet.size(), size_t(16));
+        for (size_t i = 0; i < dumpLen; ++i) {
+            char buf[8];
+            snprintf(buf, sizeof(buf), "%02X ", packet[i]);
+            hexDump += buf;
+        }
+        LOG_INFO("PenEvent", __func__, "MCU",
+                 "RX [{}B]: {}", packet.size(), hexDump);
+    }
 
     const uint8_t eventCode = packet[5];
 
@@ -113,13 +235,16 @@ void PenEventBridge::OnPacketReceived(const std::vector<uint8_t>& packet) {
     }
 
     // 3. NewPenConnectRequest (0x15) → 发送 0x2E01 确认配对握手
+    // ⚠ 未验证: 0x15 事件和 0x2E01 命令在 THP_Service.dll 中无代码引用。
+    //   此行为基于早期抓包推测。如果 MCU 不识别此命令则无效但无害。
     if (eventCode == 0x15) {
         const std::vector<uint8_t> pkt2e01 = {
-            0x07, 0x00, 0x02, 0x00, 
+            0x07, 0x00, 0x02, 0x00,
             0x01, 0x2E, 0x11, 0x00
         };
         SendRawPacket(pkt2e01);
-        LOG_INFO("PenEvent", __func__, "MCU", "Sent 0x2E01 pairing confirmation.");
+        LOG_WARN("PenEvent", __func__, "MCU",
+                 "Sent 0x2E01 pairing confirmation (UNVERIFIED command).");
     }
 
     // 4. 触发上层回调
@@ -154,7 +279,83 @@ void PenEventBridge::RunHandshake() {
     const std::vector<uint8_t> q2 = {0x07,0x00,0x02,0x00, 0x01,0x77, 0x11,0x00};
     SendRawPacket(q2);
 
-    LOG_INFO("PenEvent", __func__, "MCU", "Handshake complete.");
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    // ── 发送初始协议参数 (原厂 ReportBluetoothPenInfo → 0x7D01) ──
+    SendInitProtocolParams();
+
+    LOG_INFO("PenEvent", __func__, "MCU", "Handshake + InitProtocol complete.");
+}
+
+// ── 初始协议参数 ──────────────────────────────────────────────────────────
+// 原厂 ApDaemon::GetProtocolPrmtMode1/2 → GetProtocolInfo → ReportBluetoothPenInfo
+// 输出: "3333,3333,2e7,412,258,411a,0f,1,"
+// 这些参数通过 BtPen_GetReportInfo(event_class=2) → HandleInitParamEvent
+// 被编码为 0x7D01 二进制包发送给 MCU。
+//
+// 我们这里直接用 Type-3 编码器处理这些 hex token。
+void PenEventBridge::SendInitProtocolParams() {
+    if (!IsTransportOpen()) return;
+
+    // Factory CSV: "3333,3333,2e7,412,258,411a,0f,1,"
+    const char* tokens[] = {
+        "3333", "3333", "2e7", "412", "258", "411a", "0f", "1"
+    };
+
+    // 使用与 SendScanMode 相同的 Type-3 编码器
+    auto encodeType3Token = [](const char* hex_str, uint8_t* out) -> int {
+        int n = static_cast<int>(strlen(hex_str));
+        if (n <= 1) {
+            char h[4] = {'0', 'x', hex_str[0], '\0'};
+            out[0] = static_cast<uint8_t>(strtol(h, nullptr, 0));
+            return 1;
+        }
+        if (n == 2) {
+            char ha[4] = {'0', 'x', hex_str[1], '\0'};
+            out[0] = static_cast<uint8_t>(strtol(ha, nullptr, 0));
+            char hb[4] = {'0', 'x', hex_str[0], '\0'};
+            out[1] = static_cast<uint8_t>(strtol(hb, nullptr, 0));
+            return 2;
+        }
+        if (n == 3) {
+            char ha[5] = {'0', 'x', hex_str[1], hex_str[2], '\0'};
+            out[0] = static_cast<uint8_t>(strtol(ha, nullptr, 0));
+            char hb[4] = {'0', 'x', hex_str[0], '\0'};
+            out[1] = static_cast<uint8_t>(strtol(hb, nullptr, 0));
+            return 2;
+        }
+        // len=4
+        char ha[5] = {'0', 'x', hex_str[2], hex_str[3], '\0'};
+        out[0] = static_cast<uint8_t>(strtol(ha, nullptr, 0));
+        char hb[5] = {'0', 'x', hex_str[0], hex_str[1], '\0'};
+        out[1] = static_cast<uint8_t>(strtol(hb, nullptr, 0));
+        return 2;
+    };
+
+    uint8_t payload[0x20] = {};
+    int off = 0;
+    for (const char* tok : tokens) {
+        off += encodeType3Token(tok, payload + off);
+    }
+
+    // 构建 0x7D01 InitParam 报文
+    std::vector<uint8_t> pkt(8 + 0x20, 0);
+    pkt[0] = 0x07; pkt[1] = 0x01; pkt[2] = 0x02; pkt[3] = 0x00;
+    pkt[4] = 0x01; pkt[5] = 0x7D;
+    pkt[6] = 0x11; pkt[7] = 0x20;
+    std::copy(payload, payload + 0x20, pkt.begin() + 8);
+
+    SendRawPacket(pkt);
+
+    // 日志: dump 前 16 字节 payload
+    std::string hexDump;
+    for (int i = 0; i < off && i < 16; ++i) {
+        char buf[8];
+        snprintf(buf, sizeof(buf), "%02X ", payload[i]);
+        hexDump += buf;
+    }
+    LOG_INFO("PenEvent", __func__, "MCU",
+             "0x7D01 InitProtocolParams sent ({} bytes payload): {}", off, hexDump);
 }
 
 } // namespace Himax::Pen

--- a/EGoTouchService/Device/penevt/PenEventBridge.h
+++ b/EGoTouchService/Device/penevt/PenEventBridge.h
@@ -22,6 +22,14 @@ class PenEventBridge : public BtHidChannel {
 public:
     PenEventBridge() = default;
 
+    /// 向 BT MCU 发送 SetScanMode 命令，通知笔切换扫描频率。
+    /// 对应原厂 THP_Service::BtPen_SendPacket + ApDaemon::SetScanMode 的联合逻辑。
+    /// @param freq1  新的 TX1 频率码
+    /// @param freq2  新的 TX2 频率码
+    /// @param mode   0=正常扫描, 3=检测模式（默认 0）
+    /// @return true if packet was sent successfully
+    bool SendScanMode(uint8_t freq1, uint8_t freq2, uint8_t mode = 0);
+
     /// 设置 MCU 事件回调（线程安全）。回调从事件读取线程发起，不得长时间阻塞。
     void SetEventCallback(PenEventCallback cb);
     /// 设置状态事件句柄（用于通知 App 侧刷新状态）
@@ -43,6 +51,7 @@ private:
     void SendRawPacket(const std::vector<uint8_t>& pkt);
     void SendAck(uint8_t ackCode);
     void SendInitParamEcho(const uint8_t* data, size_t len);
+    void SendInitProtocolParams();
 
     mutable std::mutex m_cbMutex;
     PenEventCallback m_eventCallback;

--- a/EGoTouchService/Device/runtime/DeviceRuntime.cpp
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.cpp
@@ -273,8 +273,20 @@ void DeviceRuntime::OnStreaming() {
     // 1. 手写笔频率跟踪（仅 Full 模式）
     if (!touchOnly) {
         if (m_chip.m_afe.ProcessStylusStatus()) {
-            SubmitCommand({AFE_Command::ForceToFreqPoint, m_chip.m_afe.GetStylusState().switchTargetIdx},
-                          CommandSource::SystemPolicy, "Stylus Freq Sync Requested");
+            auto targetIdx = m_chip.m_afe.GetStylusState().switchTargetIdx;
+
+            // 1a. TPIC 侧切频
+            SubmitCommand({AFE_Command::ForceToFreqPoint, targetIdx},
+                          CommandSource::SystemPolicy, "Stylus Freq Sync (TP)");
+
+            // 1b. BT 笔侧切频 —— 通过 col00 通知 MCU
+            if (m_btScanModeSender) {
+                uint8_t newFreq = m_chip.m_afe.GetTpicFreq(targetIdx);
+                bool ok = m_btScanModeSender(newFreq, newFreq);
+                LOG_INFO("Runtime", __func__, "FreqSync",
+                         "BT ScanMode sent: freqIdx={}, tpicFreq=0x{:02X}, ok={}",
+                         targetIdx, newFreq, ok);
+            }
         }
     }
 

--- a/EGoTouchService/Device/runtime/DeviceRuntime.h
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.h
@@ -115,6 +115,10 @@ public:
     using BtFreqProvider = std::function<std::pair<uint8_t, uint8_t>()>;
     void SetBtFreqProvider(BtFreqProvider fn) { m_btFreqProvider = std::move(fn); }
 
+    /// BT 笔切频命令发送器：由 ServiceHost 注入，通过 PenEventBridge (col00) 发送
+    using BtScanModeSender = std::function<bool(uint8_t freq1, uint8_t freq2)>;
+    void SetBtScanModeSender(BtScanModeSender fn) { m_btScanModeSender = std::move(fn); }
+
     // Frame push callback for IPC (called after pipeline+VHF in worker loop)
     using FramePushCallback = std::function<void(const Engine::HeatmapFrame&)>;
     void SetFramePushCallback(FramePushCallback cb) { m_framePushCb = std::move(cb); }
@@ -177,6 +181,7 @@ private:
     std::atomic<uint64_t> m_nextCmdId{1};
     FramePushCallback m_framePushCb;
     BtFreqProvider m_btFreqProvider;
+    BtScanModeSender m_btScanModeSender;
 
     std::atomic<bool> m_running{false};
     std::thread m_thread;

--- a/EGoTouchService/source/ServiceHost.cpp
+++ b/EGoTouchService/source/ServiceHost.cpp
@@ -227,6 +227,16 @@ bool ServiceHost::Start() {
         m_penEventBridge->Start();
         LOG_INFO("Service", __func__, "MCU", "PenEventBridge started (col00 event channel).");
 
+        // BT 笔切频命令发送器：DeviceRuntime 在检测到频率不匹配时调用
+        if (m_deviceRuntime) {
+            m_deviceRuntime->SetBtScanModeSender(
+                [this](uint8_t freq1, uint8_t freq2) -> bool {
+                    if (!m_penEventBridge) return false;
+                    return m_penEventBridge->SendScanMode(freq1, freq2);
+                });
+            LOG_INFO("Service", __func__, "MCU", "BtScanModeSender injected via PenEventBridge (col00).");
+        }
+
         // ── 4b. 压力通道 (col01): 'U' 报文频率 + 压感 ──────
         m_penPressureReader = std::make_unique<Himax::Pen::PenPressureReader>();
         if (m_penEvent) m_penPressureReader->SetNotifyEvent(m_penEvent);


### PR DESCRIPTION
## Summary
Implement bidirectional stylus-screen frequency synchronization by transmitting `SetScanMode` via BT HID col00 channel.

## Changes
- Refactored frequency tracking in StylusState
- Mapped TPIC frequency indexes via HimaxAfe
- Injected BtScanModeSender lambda into DeviceRuntime.