### PR TITLE
refactor: split DeviceRuntime and host state updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ if (EGO_BUILD_TESTS)
         Tools/tests/SystemStateMonitorNamedEventTest.cpp
     )
     target_include_directories(HostSystemStateMonitorTest PRIVATE "${HOST_ROOT}/include")
+    target_compile_definitions(HostSystemStateMonitorTest PRIVATE EGO_SYSTEM_STATE_MONITOR_TEST_ACCESS=1)
     target_link_libraries(HostSystemStateMonitorTest PRIVATE Host Common)
 
     add_executable(SolversRawdataBenchmarkTest

--- a/EGoTouchService/Device/runtime/DeviceRuntime.cpp
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.cpp
@@ -8,18 +8,40 @@
 namespace {
 constexpr std::size_t kMaxHistoryItems = 512;
 constexpr std::chrono::milliseconds kEventDebounce{400};
+constexpr std::chrono::milliseconds kDisplayDarkGrace{1500};
+constexpr std::chrono::milliseconds kSuspendPoll{100};
+constexpr std::chrono::seconds kDisplayDarkSelfHealInterval{30};
+constexpr std::chrono::seconds kRecoverExhaustedSelfHealInterval{5};
 } // namespace
 
 // --------------- ToString helpers ---------------
 
 const char* ToString(workerState s) noexcept {
     switch (s) {
-    case workerState::suspend:   return "suspend";
-    case workerState::quit:      return "quit";
-    case workerState::ready:     return "ready";
-    case workerState::streaming: return "streaming";
-    case workerState::recover:   return "recover";
-    default:                     return "unknown";
+    case workerState::suspend:      return "suspend";
+    case workerState::display_dark: return "display_dark";
+    case workerState::quit:         return "quit";
+    case workerState::ready:        return "ready";
+    case workerState::streaming:    return "streaming";
+    case workerState::recover:      return "recover";
+    default:                        return "unknown";
+    }
+}
+
+const char* ToString(SuspendCause cause) noexcept {
+    switch (cause) {
+    case SuspendCause::None:
+        return "None";
+    case SuspendCause::DisplayDarkTimeout:
+        return "DisplayDarkTimeout";
+    case SuspendCause::LidClosed:
+        return "LidClosed";
+    case SuspendCause::SystemSleep:
+        return "SystemSleep";
+    case SuspendCause::RecoverExhausted:
+        return "RecoverExhausted";
+    default:
+        return "Unknown";
     }
 }
 
@@ -46,6 +68,9 @@ bool DeviceRuntime::Start() {
     m_stopReason.store(StopReason::None);  // ← critical: clear stop reason for restart
     SetState(workerState::ready);
     m_needSuspendDeinit = false;
+    m_suspendCause = SuspendCause::None;
+    m_suspendEnteredAt = {};
+    m_lastSelfHealAt = {};
     m_recoverCount = 0;
     m_lastNote = "Runtime started";
     m_thread = std::thread(&DeviceRuntime::WorkerMain, this);
@@ -63,6 +88,58 @@ void DeviceRuntime::Stop() {
 
 bool DeviceRuntime::IsShutdownRequested() const {
     return m_stopReason.load() == StopReason::Shutdown;
+}
+
+void DeviceRuntime::RequestSoftDisplayPause() {
+    m_chip.CancelPendingFrameRead();
+
+    const auto state = m_state.load(std::memory_order_acquire);
+    if (state == workerState::suspend) {
+        LOG_INFO("Runtime", __func__, "Policy", "DisplayOff ignored because runtime is already in hard suspend.");
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        m_suspendCause = SuspendCause::None;
+        m_suspendEnteredAt = std::chrono::steady_clock::now();
+        m_lastNote = "Display dark: frame IO paused";
+    }
+
+    if (state != workerState::display_dark) {
+        m_stopReason.store(StopReason::DisplayDark, std::memory_order_release);
+    }
+}
+
+void DeviceRuntime::RequestHardSuspend(SuspendCause cause, const char* reason) {
+    m_chip.CancelPendingFrameRead();
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        m_suspendCause = cause;
+        m_suspendEnteredAt = std::chrono::steady_clock::now();
+        m_lastNote = std::string("Hard suspend requested: ") + (reason ? reason : "unknown");
+    }
+    m_stopReason.store(StopReason::HardSuspend, std::memory_order_release);
+}
+
+void DeviceRuntime::ResumeFromPause(const char* reason) {
+    m_stopReason.store(StopReason::None, std::memory_order_release);
+    m_needSuspendDeinit = false;
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        m_suspendCause = SuspendCause::None;
+        m_suspendEnteredAt = {};
+        m_lastSelfHealAt = {};
+        m_lastNote = std::string("Resumed by ") + (reason ? reason : "unknown");
+    }
+
+    const auto state = m_state.load(std::memory_order_acquire);
+    if (state == workerState::suspend || state == workerState::display_dark) {
+        SetState(workerState::ready);
+        LOG_INFO("Runtime", __func__, "Policy", "Resume request '{}' moved runtime to ready.", reason ? reason : "unknown");
+    } else if (state != workerState::quit) {
+        LOG_INFO("Runtime", __func__, "Policy", "Resume request '{}' ignored in state={}", reason ? reason : "unknown", ToString(state));
+    }
 }
 
 // --------------- 命令注入 ---------------
@@ -96,29 +173,25 @@ void DeviceRuntime::IngestSystemEvent(
     using ET = Host::SystemStateEventType;
     switch (ev.type) {
     case ET::DisplayOff:
+        LOG_INFO("Runtime", __func__, "Policy", "DisplayOff received, pausing frame IO without hard suspend.");
+        RequestSoftDisplayPause();
+        break;
     case ET::LidOff:
-        LOG_INFO("Runtime", __func__, "Policy", "Sleep event ({}), requesting suspend.", Host::ToString(ev.type));
-        m_chip.CancelPendingFrameRead();  // abort any blocking GetFrame NOW
-        m_stopReason.store(StopReason::ScreenOff);
+        LOG_INFO("Runtime", __func__, "Policy", "LidOff received, requesting hard suspend.");
+        RequestHardSuspend(SuspendCause::LidClosed, "LidOff");
         break;
     case ET::DisplayOn:
     case ET::LidOn:
     case ET::ResumeAutomatic:
         LOG_INFO("Runtime", __func__, "Policy", "Wake event ({}), attempting resume.", Host::ToString(ev.type));
-        // suspend 状态下直接恢复，无需重建线程
-        if (m_state.load() == workerState::suspend) {
-            SetState(workerState::ready);
-            LOG_INFO("Runtime", __func__, "Policy", "Resumed from suspend -> ready (zero-cost wakeup).");
-        } else {
-            Stop();
-            Start();
-        }
+        ResumeFromPause(Host::ToString(ev.type));
         break;
     case ET::Shutdown:
         LOG_INFO("Runtime", __func__, "Policy", "Shutdown event, requesting termination.");
         m_stopReason.store(StopReason::Shutdown);
         break;
-    default: break;
+    default:
+        break;
     }
 }
 
@@ -133,6 +206,7 @@ RuntimeSnapshot DeviceRuntime::GetSnapshot() const {
     s.queue_depth = m_cmdQueue.size();
     s.last_command_id = m_lastCmdId;
     s.last_note = m_lastNote;
+    s.suspend_cause = m_suspendCause;
     return s;
 }
 
@@ -194,14 +268,27 @@ bool DeviceRuntime::DrainCommands() {
 
 ThreadResult DeviceRuntime::WorkerMain() {
     while (true) {
-        // ── 检查停止请求，根据 StopReason 分流到 suspend 或 quit ──
+        // ── 检查停止请求，根据 StopReason 分流到 display_dark / suspend / quit ──
         auto reason = m_stopReason.exchange(StopReason::None,
                                             std::memory_order_acq_rel);
         if (reason != StopReason::None) {
-            if (reason == StopReason::ScreenOff) {
-                LOG_INFO("Runtime", __func__, "StopReq", "StopReason::ScreenOff consumed -> suspend");
+            if (reason == StopReason::DisplayDark) {
+                LOG_INFO("Runtime", __func__, "StopReq", "StopReason::DisplayDark consumed -> display_dark");
+                SetState(workerState::display_dark);
+                {
+                    std::lock_guard<std::mutex> lk(m_mu);
+                    m_suspendEnteredAt = std::chrono::steady_clock::now();
+                }
+            } else if (reason == StopReason::HardSuspend) {
+                LOG_INFO("Runtime", __func__, "StopReq", "StopReason::HardSuspend consumed -> suspend");
                 SetState(workerState::suspend);
-                m_needSuspendDeinit = true;   // 延迟到 OnSuspend 首次进入时执行
+                m_needSuspendDeinit = true;
+                {
+                    std::lock_guard<std::mutex> lk(m_mu);
+                    if (m_suspendEnteredAt == std::chrono::steady_clock::time_point{}) {
+                        m_suspendEnteredAt = std::chrono::steady_clock::now();
+                    }
+                }
             } else {
                 LOG_INFO("Runtime", __func__, "StopReq", "StopReason::Shutdown consumed -> quit");
                 SetState(workerState::quit);
@@ -214,10 +301,11 @@ ThreadResult DeviceRuntime::WorkerMain() {
 
         auto curState = m_state.load(std::memory_order_acquire);
         switch (curState) {
-        case workerState::ready:     OnReady();     break;
-        case workerState::streaming: OnStreaming();  break;
-        case workerState::recover:   OnRecover();   break;
-        case workerState::suspend:   OnSuspend();   break;
+        case workerState::ready:        OnReady();     break;
+        case workerState::streaming:    OnStreaming(); break;
+        case workerState::recover:      OnRecover();   break;
+        case workerState::display_dark: OnSuspend();   break;
+        case workerState::suspend:      OnSuspend();   break;
         case workerState::quit:
             if (OnQuit()) {
                 m_running.store(false);  // allow restart via Start()
@@ -391,14 +479,68 @@ bool DeviceRuntime::OnQuit() {
 }
 
 void DeviceRuntime::OnSuspend() {
-    // 首次进入 suspend 时执行 HoldReset（拉低 reset，关闭中断通道）
+    const auto state = m_state.load(std::memory_order_acquire);
+    const auto now = std::chrono::steady_clock::now();
+
+    if (state == workerState::display_dark) {
+        const auto enteredAt = m_suspendEnteredAt;
+        if (enteredAt != std::chrono::steady_clock::time_point{} && now - enteredAt >= kDisplayDarkGrace) {
+            {
+                std::lock_guard<std::mutex> lk(m_mu);
+                m_suspendCause = SuspendCause::DisplayDarkTimeout;
+                m_suspendEnteredAt = now;
+                m_lastNote = "Display dark persisted; escalating to hard suspend";
+            }
+            m_stopReason.store(StopReason::HardSuspend, std::memory_order_release);
+            LOG_WARN("Runtime", __func__, "display_dark", "Display stayed dark for {} ms; escalating to hard suspend.", kDisplayDarkGrace.count());
+            return;
+        }
+
+        std::this_thread::sleep_for(kSuspendPoll);
+        return;
+    }
+
+    // 首次进入 hard suspend 时执行 HoldReset（拉低 reset，关闭中断通道）
     if (m_needSuspendDeinit) {
         m_chip.HoldReset();
         m_needSuspendDeinit = false;
-        LOG_INFO("Runtime", __func__, "suspend", "Entered suspend, chip reset held low. Waiting for wake event.");
+        {
+            std::lock_guard<std::mutex> lk(m_mu);
+            if (m_suspendEnteredAt == std::chrono::steady_clock::time_point{}) {
+                m_suspendEnteredAt = now;
+            }
+            m_lastNote = std::string("Hard suspend active: ") + ToString(m_suspendCause);
+        }
+        LOG_INFO("Runtime", __func__, "suspend", "Entered suspend, chip reset held low. cause={}", ToString(m_suspendCause));
     }
+
+    const auto enteredAt = m_suspendEnteredAt;
+    const auto lastSelfHealAt = m_lastSelfHealAt;
+    const bool shouldSelfHeal =
+        (m_suspendCause == SuspendCause::RecoverExhausted &&
+         enteredAt != std::chrono::steady_clock::time_point{} &&
+         now - enteredAt >= kRecoverExhaustedSelfHealInterval &&
+         (lastSelfHealAt == std::chrono::steady_clock::time_point{} ||
+          now - lastSelfHealAt >= kRecoverExhaustedSelfHealInterval)) ||
+        (m_suspendCause == SuspendCause::DisplayDarkTimeout &&
+         enteredAt != std::chrono::steady_clock::time_point{} &&
+         now - enteredAt >= kDisplayDarkSelfHealInterval &&
+         (lastSelfHealAt == std::chrono::steady_clock::time_point{} ||
+          now - lastSelfHealAt >= kDisplayDarkSelfHealInterval));
+
+    if (shouldSelfHeal) {
+        {
+            std::lock_guard<std::mutex> lk(m_mu);
+            m_lastSelfHealAt = now;
+            m_lastNote = std::string("Self-heal triggered from suspend: ") + ToString(m_suspendCause);
+        }
+        LOG_WARN("Runtime", __func__, "suspend", "Self-heal triggered while suspended. cause={}", ToString(m_suspendCause));
+        SetState(workerState::ready);
+        return;
+    }
+
     // 低功耗等待，每 100ms 检查一次状态变更
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(kSuspendPoll);
 }
 
 void DeviceRuntime::OnRecover() {
@@ -406,10 +548,9 @@ void DeviceRuntime::OnRecover() {
 
     // 最大重试 30 次（500ms 间隔 ≈ 15 秒恢复窗口）
     if (m_recoverCount > 30) {
-        LOG_ERROR("Runtime", __func__, "Recover", "Exceeded 30 recovery attempts, entering suspend.");
+        LOG_ERROR("Runtime", __func__, "Recover", "Exceeded 30 recovery attempts, entering self-healing suspend.");
         m_recoverCount = 0;
-        m_needSuspendDeinit = true;
-        SetState(workerState::suspend);
+        RequestHardSuspend(SuspendCause::RecoverExhausted, "RecoverExhausted");
         return;
     }
 

--- a/EGoTouchService/Device/runtime/DeviceRuntime.h
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.h
@@ -27,21 +27,32 @@ enum class result { error, timeout };
 using ThreadResult = std::expected<void, result>;
 
 enum class workerState {
-    suspend  = -2,   // 屏幕关闭/合盖 → worker 暂停（线程保留，等待唤醒）
-    quit     = -1,   // 服务终止/系统关机 → worker 线程退出
-    ready    =  0,   // 初始就绪
-    streaming,       // 正在采帧
-    recover,         // 恢复中
+    suspend      = -3,   // 硬 suspend：reset 拉低，等待唤醒/自愈
+    display_dark = -2,   // 软停 IO：屏幕短暂关闭或显示路径切换
+    quit         = -1,   // 服务终止/系统关机 → worker 线程退出
+    ready        =  0,   // 初始就绪
+    streaming,          // 正在采帧
+    recover,            // 恢复中
 };
 
 /// 停止原因（替代原来的 m_stopReq + m_shutdownReq 双 flag）
 enum class StopReason : uint8_t {
     None = 0,
-    ScreenOff,   // DisplayOff / LidOff → 进入 suspend
-    Shutdown,    // 系统关机 / Stop() → 进入 quit
+    DisplayDark,   // DisplayOff → 先软停 IO，再视情况升级为硬 suspend
+    HardSuspend,   // LidOff / 系统挂起 / recover exhausted → 进入 suspend
+    Shutdown,      // 系统关机 / Stop() → 进入 quit
+};
+
+enum class SuspendCause : uint8_t {
+    None = 0,
+    DisplayDarkTimeout,
+    LidClosed,
+    SystemSleep,
+    RecoverExhausted,
 };
 
 const char* ToString(workerState s) noexcept;
+const char* ToString(SuspendCause cause) noexcept;
 
 enum class CommandSource : uint8_t {
     External = 0,
@@ -67,6 +78,7 @@ struct RuntimeSnapshot {
     std::size_t queue_depth = 0;
     uint64_t last_command_id = 0;
     std::string last_note;
+    SuspendCause suspend_cause = SuspendCause::None;
 };
 
 // --------------- DeviceRuntime ---------------
@@ -84,7 +96,10 @@ public:
     void Stop();
     bool IsShutdownRequested() const;
     bool IsRunning() const { return m_running.load(); }
-    bool IsSuspended() const { return m_state.load() == workerState::suspend; }
+    bool IsSuspended() const {
+        const auto state = m_state.load();
+        return state == workerState::suspend || state == workerState::display_dark;
+    }
 
     // Auto/Manual 模式
     void SetAutoMode(bool enabled) { m_autoMode.store(enabled); }
@@ -104,6 +119,10 @@ public:
 
     /// 注入 BT MCU 压感值（由 PenBridge 线程写入，StylusPipeline 帧内读取）
     void SetBtMcuPressure(uint16_t p) { m_stylusPipeline.SetBtMcuPressure(p); }
+    void SetBtMcuPressureSequence(uint16_t p0, uint16_t p1,
+                                  uint16_t p2, uint16_t p3) {
+        m_stylusPipeline.SetBtMcuPressureSequence(p0, p1, p2, p3);
+    }
 
     /// 蓝牙按键数据注入（由 PenBridge / BLE 线程写入）
     void UpdateButtonFromBle(uint8_t raw) { m_stylusPipeline.UpdateButtonFromBle(raw); }
@@ -156,6 +175,9 @@ private:
                        bool ok, const std::string& det);
 
     void SetState(workerState newState);
+    void RequestSoftDisplayPause();
+    void RequestHardSuspend(SuspendCause cause, const char* reason);
+    void ResumeFromPause(const char* reason);
     std::atomic<workerState> m_state{workerState::quit};
     std::atomic<StopReason> m_stopReason{StopReason::None};
     std::atomic<bool> m_autoMode{false};
@@ -166,6 +188,9 @@ private:
     VhfReporter m_vhfReporter;
     uint8_t m_recoverCount = 0;
     bool m_needSuspendDeinit = false;  // suspend 首次进入时执行 Deinit
+    SuspendCause m_suspendCause = SuspendCause::None;
+    std::chrono::steady_clock::time_point m_suspendEnteredAt{};
+    std::chrono::steady_clock::time_point m_lastSelfHealAt{};
 
     // GetFrame 连续非Timeout失败计数（容忍 AFE 命令后的短暂 bus 异常）
     static constexpr int kMaxConsecutiveFrameErrors = 3;

--- a/EGoTouchService/Device/runtime/DeviceRuntime.h
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.h
@@ -119,10 +119,6 @@ public:
 
     /// 注入 BT MCU 压感值（由 PenBridge 线程写入，StylusPipeline 帧内读取）
     void SetBtMcuPressure(uint16_t p) { m_stylusPipeline.SetBtMcuPressure(p); }
-    void SetBtMcuPressureSequence(uint16_t p0, uint16_t p1,
-                                  uint16_t p2, uint16_t p3) {
-        m_stylusPipeline.SetBtMcuPressureSequence(p0, p1, p2, p3);
-    }
 
     /// 蓝牙按键数据注入（由 PenBridge / BLE 线程写入）
     void UpdateButtonFromBle(uint8_t raw) { m_stylusPipeline.UpdateButtonFromBle(raw); }

--- a/EGoTouchService/Host/SystemStateMonitor.cpp
+++ b/EGoTouchService/Host/SystemStateMonitor.cpp
@@ -2,6 +2,8 @@
 #include "Logger.h"
 
 #include <array>
+#include <string>
+#include <string_view>
 #include <utility>
 #include <sddl.h>
 
@@ -26,6 +28,14 @@ HANDLE OpenOrCreateNamedEvent(const wchar_t* name) {
         return handle;
     }
 
+    std::wstring local_name = Host::SystemStateMonitor::NormalizeEventName(name);
+    if (local_name != name) {
+        handle = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, local_name.c_str());
+        if (handle != nullptr) {
+            return handle;
+        }
+    }
+
     SECURITY_ATTRIBUTES sa{};
     sa.nLength = sizeof(sa);
     sa.bInheritHandle = FALSE;
@@ -46,6 +56,9 @@ HANDLE OpenOrCreateNamedEvent(const wchar_t* name) {
     }
 
     HANDLE new_handle = CreateEventW(sa.lpSecurityDescriptor ? &sa : nullptr, TRUE, FALSE, name);
+    if (new_handle == nullptr && GetLastError() == ERROR_ACCESS_DENIED && local_name != name) {
+        new_handle = CreateEventW(sa.lpSecurityDescriptor ? &sa : nullptr, TRUE, FALSE, local_name.c_str());
+    }
 
     if (sa.lpSecurityDescriptor != nullptr) {
         LocalFree(sa.lpSecurityDescriptor);
@@ -55,6 +68,23 @@ HANDLE OpenOrCreateNamedEvent(const wchar_t* name) {
 }
 
 } // namespace
+
+std::wstring SystemStateMonitor::NormalizeEventName(const wchar_t* name) noexcept {
+    if (name == nullptr) {
+        return {};
+    }
+
+    constexpr std::wstring_view kGlobalPrefix = L"Global\\";
+    constexpr std::wstring_view kLocalPrefix = L"Local\\";
+    std::wstring_view view{name};
+    if (!view.starts_with(kGlobalPrefix)) {
+        return std::wstring{view};
+    }
+
+    std::wstring local_name{kLocalPrefix};
+    local_name.append(view.substr(kGlobalPrefix.size()));
+    return local_name;
+}
 
 const char* ToString(SystemStateEventType type) noexcept {
     switch (type) {

--- a/EGoTouchService/Host/SystemStateMonitor.h
+++ b/EGoTouchService/Host/SystemStateMonitor.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <cstddef>
 #include <functional>
+#include <string>
 #include <thread>
 #include <windows.h>
 
@@ -31,14 +32,19 @@ public:
     bool IsRunning() const noexcept;
 
     static const std::array<const wchar_t*, kEventCount>& NamedEventList() noexcept;
+    static std::wstring NormalizeEventName(const wchar_t* name) noexcept;
 
-private:
+#if defined(EGO_SYSTEM_STATE_MONITOR_TEST_ACCESS)
+public:
+#endif
     bool OpenOrCreateEvents();
     void CloseEvents() noexcept;
     void WorkerLoop();
     static SystemStateEvent BuildEvent(std::size_t index);
 
+#if !defined(EGO_SYSTEM_STATE_MONITOR_TEST_ACCESS)
 private:
+#endif
     std::array<HANDLE, kEventCount> m_events{};
     HANDLE m_stopEvent = nullptr;
     EventCallback m_callback;

--- a/EGoTouchService/source/ServiceHost.cpp
+++ b/EGoTouchService/source/ServiceHost.cpp
@@ -309,8 +309,8 @@ bool ServiceHost::Start() {
         m_penPressureReader = std::make_unique<Himax::Pen::PenPressureReader>();
         if (m_penEvent) m_penPressureReader->SetNotifyEvent(m_penEvent);
         m_penPressureReader->SetPressureCallback(
-            [this](uint16_t p0, uint16_t p1, uint16_t p2, uint16_t p3) {
-                if (m_deviceRuntime) m_deviceRuntime->SetBtMcuPressureSequence(p0, p1, p2, p3);
+            [this](uint16_t press) {
+                if (m_deviceRuntime) m_deviceRuntime->SetBtMcuPressure(press);
             });
 
         // BT 频率提供者：DeviceRuntime 每帧 poll 获取最新 BT MCU 频率

--- a/EGoTouchService/source/ServiceHost.cpp
+++ b/EGoTouchService/source/ServiceHost.cpp
@@ -309,8 +309,8 @@ bool ServiceHost::Start() {
         m_penPressureReader = std::make_unique<Himax::Pen::PenPressureReader>();
         if (m_penEvent) m_penPressureReader->SetNotifyEvent(m_penEvent);
         m_penPressureReader->SetPressureCallback(
-            [this](uint16_t press) {
-                if (m_deviceRuntime) m_deviceRuntime->SetBtMcuPressure(press);
+            [this](uint16_t p0, uint16_t p1, uint16_t p2, uint16_t p3) {
+                if (m_deviceRuntime) m_deviceRuntime->SetBtMcuPressureSequence(p0, p1, p2, p3);
             });
 
         // BT 频率提供者：DeviceRuntime 每帧 poll 获取最新 BT MCU 频率

--- a/EGoTouchService/source/ServiceShell.cpp
+++ b/EGoTouchService/source/ServiceShell.cpp
@@ -51,11 +51,20 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
     auto* s = static_cast<ServiceShell*>(ctx);
 
     // Helper: signal a named event by index
-    auto signalEvent = [](std::size_t idx) {
+    auto signalEvent = [](std::size_t idx, std::string_view reason) {
         const auto& names = Host::SystemStateMonitor::NamedEventList();
-        if (idx >= names.size()) return;
+        if (idx >= names.size()) {
+            LOG_WARN("Service", __func__, "Power", "Skip signal for '{}' due to invalid event index={}", reason, idx);
+            return;
+        }
         HANDLE h = OpenEventW(EVENT_MODIFY_STATE, FALSE, names[idx]);
-        if (h) { SetEvent(h); CloseHandle(h); }
+        if (!h) {
+            LOG_WARN("Service", __func__, "Power", "OpenEvent failed for '{}' (index={}, err={})", reason, idx, GetLastError());
+            return;
+        }
+        SetEvent(h);
+        CloseHandle(h);
+        LOG_INFO("Service", __func__, "Power", "Signaled named event '{}' (index={}).", reason, idx);
     };
 
     switch (ctrl) {
@@ -64,23 +73,12 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
     case SERVICE_CONTROL_PRESHUTDOWN:
         LOG_INFO("Service", __func__, "Stopping", "Received stop/shutdown control code={}.", ctrl);
         // Signal MonitorShutDownEvent (index 6) so monitor thread sees it
-        signalEvent(6);
+        signalEvent(6, "Shutdown");
         s->ReportStatus(SERVICE_STOP_PENDING, 5000);
         SetEvent(s->m_stopEvent);
         return NO_ERROR;
 
     case SERVICE_CONTROL_POWEREVENT: {
-        // Handle PBT_APMRESUMEAUTOMATIC (system resumed from sleep)
-        if (evtType == PBT_APMRESUMEAUTOMATIC) {
-            LOG_INFO("Service", __func__, "Power", "PBT_APMRESUMEAUTOMATIC");
-            signalEvent(7);  // PBT_APMRESUMEAUTOMATIC event
-            return NO_ERROR;
-        }
-
-        if (evtType != PBT_POWERSETTINGCHANGE || !evtData)
-            return NO_ERROR;
-        auto* pbs = static_cast<POWERBROADCAST_SETTING*>(evtData);
-
         // GUID_CONSOLE_DISPLAY_STATE: 0=off, 1=on, 2=dimmed
         static const GUID kDisplayGuid =
             {0x6fe69556, 0x704a, 0x47a0,
@@ -89,26 +87,71 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
         static const GUID kLidGuid =
             {0xba3e0f4d, 0xb817, 0x4094,
              {0xa2, 0xd1, 0xd5, 0x63, 0x79, 0xe6, 0xa0, 0xf3}};
+        // GUID_SYSTEM_AWAYMODE (away mode / connected standby)
+        static const GUID kAwayGuid =
+            {0x98a7f580, 0x01f7, 0x48aa,
+             {0x9c, 0x0f, 0x44, 0x35, 0x2c, 0x29, 0xe5, 0xc0}};
 
+        switch (evtType) {
+        case PBT_APMSUSPEND:
+            LOG_INFO("Service", __func__, "Power", "PBT_APMSUSPEND -> suspend path");
+            signalEvent(1, "PBT_APMSUSPEND");
+            return NO_ERROR;
+        case PBT_APMRESUMEAUTOMATIC:
+            LOG_INFO("Service", __func__, "Power", "PBT_APMRESUMEAUTOMATIC -> wake path");
+            signalEvent(7, "PBT_APMRESUMEAUTOMATIC");
+            return NO_ERROR;
+        case PBT_APMRESUMESUSPEND:
+            LOG_INFO("Service", __func__, "Power", "PBT_APMRESUMESUSPEND -> wake path");
+            signalEvent(7, "PBT_APMRESUMESUSPEND");
+            return NO_ERROR;
+        case PBT_APMRESUMECRITICAL:
+            LOG_INFO("Service", __func__, "Power", "PBT_APMRESUMECRITICAL -> wake path");
+            signalEvent(7, "PBT_APMRESUMECRITICAL");
+            return NO_ERROR;
+        case PBT_POWERSETTINGCHANGE:
+            break;
+        default:
+            LOG_INFO("Service", __func__, "Power", "Ignored power event ctrl={}, evtType={}", ctrl, evtType);
+            return NO_ERROR;
+        }
+
+        if (!evtData) {
+            LOG_WARN("Service", __func__, "Power", "PBT_POWERSETTINGCHANGE without evtData.");
+            return NO_ERROR;
+        }
+
+        auto* pbs = static_cast<POWERBROADCAST_SETTING*>(evtData);
         if (pbs->PowerSetting == kDisplayGuid && pbs->DataLength >= 4) {
             DWORD state = *reinterpret_cast<DWORD*>(pbs->Data);
             LOG_INFO("Service", __func__, "Power", "GUID_CONSOLE_DISPLAY_STATE = {}", state);
             if (state >= 1) {
-                signalEvent(0);  // MonitorPowerOnEvent
-                signalEvent(2);  // MonitorConsoleDisplayOnEvent
+                signalEvent(0, "DisplayOn(Power)");
+                signalEvent(2, "DisplayOn(Console)");
             } else {
-                signalEvent(1);  // MonitorPowerOffEvent
-                signalEvent(3);  // MonitorConsoleDisplayOffEvent
+                signalEvent(1, "DisplayOff(Power)");
+                signalEvent(3, "DisplayOff(Console)");
             }
         }
         else if (pbs->PowerSetting == kLidGuid && pbs->DataLength >= 4) {
             DWORD state = *reinterpret_cast<DWORD*>(pbs->Data);
             LOG_INFO("Service", __func__, "Power", "GUID_LIDSWITCH_STATE = {} (1=open, 0=closed)", state);
             if (state == 1) {
-                signalEvent(4);  // MonitorLidOnEvent
+                signalEvent(4, "LidOn");
             } else {
-                signalEvent(5);  // MonitorLidOffEvent
+                signalEvent(5, "LidOff");
             }
+        }
+        else if (pbs->PowerSetting == kAwayGuid && pbs->DataLength >= 4) {
+            DWORD state = *reinterpret_cast<DWORD*>(pbs->Data);
+            LOG_INFO("Service", __func__, "Power", "GUID_SYSTEM_AWAYMODE = {} (1=enter, 0=exit)", state);
+            if (state == 0) {
+                signalEvent(7, "AwayModeExit");
+            } else {
+                signalEvent(1, "AwayModeEnter");
+            }
+        } else {
+            LOG_INFO("Service", __func__, "Power", "Unhandled power setting GUID with dataLength={}", pbs->DataLength);
         }
         return NO_ERROR;
     }

--- a/Tools/tests/SystemStateMonitorNamedEventTest.cpp
+++ b/Tools/tests/SystemStateMonitorNamedEventTest.cpp
@@ -7,37 +7,12 @@
 #include <cstddef>
 #include <iostream>
 #include <mutex>
+#include <string>
 #include <string_view>
 #include <thread>
 #include <vector>
 
 namespace {
-
-bool SignalNamedEvent(const wchar_t* event_name) {
-    HANDLE event_handle = OpenEventW(EVENT_MODIFY_STATE, FALSE, event_name);
-    if (event_handle == nullptr) {
-        std::wcerr << L"[TEST] OpenEvent failed: " << event_name << L", gle=" << GetLastError() << L"\n";
-        return false;
-    }
-
-    const BOOL ok = SetEvent(event_handle);
-    const DWORD err = ok ? ERROR_SUCCESS : GetLastError();
-    CloseHandle(event_handle);
-
-    if (!ok) {
-        std::wcerr << L"[TEST] SetEvent failed: " << event_name << L", gle=" << err << L"\n";
-    }
-    return ok == TRUE;
-}
-
-void ResetNamedEventBestEffort(const wchar_t* event_name) {
-    HANDLE event_handle = OpenEventW(EVENT_MODIFY_STATE, FALSE, event_name);
-    if (event_handle == nullptr) {
-        return;
-    }
-    ResetEvent(event_handle);
-    CloseHandle(event_handle);
-}
 
 bool ExpectSequence(const std::vector<Host::SystemStateEventType>& expected,
                     const std::vector<Host::SystemStateEventType>& actual) {
@@ -78,25 +53,41 @@ int main() {
         return 1;
     }
 
-    const auto& named_events = Host::SystemStateMonitor::NamedEventList();
-    for (const wchar_t* event_name : named_events) {
-        ResetNamedEventBestEffort(event_name);
+    for (HANDLE event_handle : monitor.m_events) {
+        if (event_handle != nullptr && event_handle != INVALID_HANDLE_VALUE) {
+            ResetEvent(event_handle);
+        }
     }
 
     // Give worker thread a short warm-up window before injecting events.
     std::this_thread::sleep_for(80ms);
 
     const std::vector<std::pair<std::size_t, Host::SystemStateEventType>> script = {
+        {1, Host::SystemStateEventType::DisplayOff},
+        {0, Host::SystemStateEventType::DisplayOn},
         {3, Host::SystemStateEventType::DisplayOff},
         {2, Host::SystemStateEventType::DisplayOn},
         {5, Host::SystemStateEventType::LidOff},
+        {4, Host::SystemStateEventType::LidOn},
+        {6, Host::SystemStateEventType::Shutdown},
         {7, Host::SystemStateEventType::ResumeAutomatic},
     };
 
     for (const auto& step : script) {
         const std::size_t index = step.first;
-        if (!SignalNamedEvent(named_events[index])) {
+        if (index >= monitor.m_events.size()) {
             monitor.Stop();
+            return 2;
+        }
+        HANDLE event_handle = monitor.m_events[index];
+        if (event_handle == nullptr || event_handle == INVALID_HANDLE_VALUE) {
+            monitor.Stop();
+            std::cerr << "[TEST] Invalid event handle for index=" << index << "\n";
+            return 2;
+        }
+        if (!SetEvent(event_handle)) {
+            monitor.Stop();
+            std::cerr << "[TEST] SetEvent failed for index=" << index << ", gle=" << GetLastError() << "\n";
             return 2;
         }
         std::this_thread::sleep_for(20ms);
@@ -105,7 +96,11 @@ int main() {
     const std::vector<Host::SystemStateEventType> expected = {
         Host::SystemStateEventType::DisplayOff,
         Host::SystemStateEventType::DisplayOn,
+        Host::SystemStateEventType::DisplayOff,
+        Host::SystemStateEventType::DisplayOn,
         Host::SystemStateEventType::LidOff,
+        Host::SystemStateEventType::LidOn,
+        Host::SystemStateEventType::Shutdown,
         Host::SystemStateEventType::ResumeAutomatic,
     };
 


### PR DESCRIPTION
## Summary
- Move DeviceRuntime/Host/SystemStateMonitor related changes into an independent branch
- Keep stylus algorithm PR scope focused by separating runtime/host concerns
- Include corresponding named-event test updates

## Test plan
- [ ] Build EGoTouchService
- [ ] Run `Tools/tests/SystemStateMonitorNamedEventTest.cpp` related tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)