### PR TITLE
feat: canonical IPC config contract

### DIFF
--- a/Common/include/IpcPipeClient.h
+++ b/Common/include/IpcPipeClient.h
@@ -33,6 +33,9 @@ public:
     IpcResponse StopRuntime();
     IpcResponse ReloadConfig();
     IpcResponse SaveConfig();
+    IpcResponse GetConfigSnapshot();
+    IpcResponse ApplyConfigPatch(const ApplyConfigPatchRequestWire& patch);
+    IpcResponse PersistConfig();
 
 private:
     HANDLE m_pipe = INVALID_HANDLE_VALUE;

--- a/Common/include/IpcProtocol.h
+++ b/Common/include/IpcProtocol.h
@@ -5,11 +5,17 @@
 
 namespace Ipc {
 
+constexpr uint16_t kIpcProtocolVersion = 2;
+
 constexpr const wchar_t* kPipeName = L"\\\\.\\pipe\\EGoTouchControl";
 // IPC-related global events
 constexpr const wchar_t* kLogReadyEventName = L"Global\\EGoTouchLogReady";
 constexpr const wchar_t* kPenReadyEventName = L"Global\\EGoTouchPenStatusReady";
 
+// NOTE:
+// - ReloadConfig / SaveConfig remain for transition compatibility.
+// - GetConfigSnapshot / ApplyConfigPatch / PersistConfig are the Phase 0
+//   canonical config-control commands.
 enum class IpcCommand : uint8_t {
     Ping = 0,
     // Debug mode: App tells Service to open shared memory and start pushing
@@ -23,9 +29,13 @@ enum class IpcCommand : uint8_t {
     // VHF
     SetVhfEnabled    = 30,
     SetVhfTranspose  = 31,
-    // Config
+    // Config (legacy compatibility)
     ReloadConfig   = 40,  // Re-read config.ini; response data may include ReloadConfigSummaryWire
-    SaveConfig     = 41,  // Service saves current params to config.ini
+    SaveConfig     = 41,  // Legacy alias for PersistConfig
+    // Config (Phase 0 canonical control path)
+    GetConfigSnapshot = 42,
+    ApplyConfigPatch  = 43,
+    PersistConfig     = 44,
     // Logs
     GetLogs        = 50,  // App requests recent log lines from Service
     // PenBridge (BT MCU)
@@ -33,6 +43,72 @@ enum class IpcCommand : uint8_t {
     // Dynamic debug metadata + values
     GetDebugSchema   = 61,
     GetDebugSnapshot = 62,
+};
+
+enum class IpcStatusCode : uint8_t {
+    Ok = 0,
+    UnsupportedCommand = 1,
+    InvalidRequest = 2,
+    InvalidState = 3,
+    NotFound = 4,
+    PermissionDenied = 5,
+    InternalError = 6,
+};
+
+enum class ServiceModeWire : uint8_t {
+    Full = 0,
+    TouchOnly = 1,
+};
+
+enum class ServiceConfigFieldWire : uint8_t {
+    None = 0,
+    Mode = 1u << 0,
+    AutoMode = 1u << 1,
+    StylusVhfEnabled = 1u << 2,
+};
+
+constexpr uint8_t ToBits(ServiceConfigFieldWire field) noexcept {
+    return static_cast<uint8_t>(field);
+}
+
+constexpr bool HasField(uint8_t fieldMask, ServiceConfigFieldWire field) noexcept {
+    return (fieldMask & ToBits(field)) != 0;
+}
+
+struct ConfigSnapshotWire {
+    uint16_t wireVersion = kIpcProtocolVersion;
+    uint8_t definedFields =
+        ToBits(ServiceConfigFieldWire::Mode) |
+        ToBits(ServiceConfigFieldWire::AutoMode) |
+        ToBits(ServiceConfigFieldWire::StylusVhfEnabled);
+    uint8_t desiredMode = static_cast<uint8_t>(ServiceModeWire::Full);
+    uint8_t activeMode = static_cast<uint8_t>(ServiceModeWire::Full);
+    uint8_t autoMode = 1;
+    uint8_t stylusVhfEnabled = 1;
+    uint8_t _reserved0 = 0;
+};
+
+struct ApplyConfigPatchRequestWire {
+    uint16_t wireVersion = kIpcProtocolVersion;
+    uint8_t fieldMask = 0;
+    uint8_t desiredMode = static_cast<uint8_t>(ServiceModeWire::Full);
+    uint8_t autoMode = 1;
+    uint8_t stylusVhfEnabled = 1;
+    uint8_t _reserved0 = 0;
+};
+
+struct ConfigMutationResultWire {
+    uint16_t wireVersion = kIpcProtocolVersion;
+    uint8_t changedFields = 0;
+    uint8_t appliedFields = 0;
+    uint8_t restartRequiredFields = 0;
+    uint8_t _reserved0 = 0;
+};
+
+struct PersistConfigResponseWire {
+    uint16_t wireVersion = kIpcProtocolVersion;
+    uint8_t persistedFields = 0;
+    uint8_t _reserved0 = 0;
 };
 
 enum class DebugValueType : uint8_t {
@@ -145,6 +221,7 @@ struct DebugSnapshotValueWire {
     uint64_t rawValue = 0;
 };
 
+// Legacy response wire for ReloadConfig. Keep the 3-byte layout for transition compatibility.
 struct ReloadConfigSummaryWire {
     // Bit layout (LSB-first):
     // bit0: [Service].mode
@@ -162,9 +239,20 @@ struct IpcRequest {
 };
 
 struct IpcResponse {
+    IpcStatusCode status = IpcStatusCode::InternalError;
     bool     success = false;
     uint16_t dataLen = 0;
     uint8_t  data[4096]{};
 };
+
+inline void MarkSuccess(IpcResponse& resp) noexcept {
+    resp.success = true;
+    resp.status = IpcStatusCode::Ok;
+}
+
+inline void MarkFailure(IpcResponse& resp, IpcStatusCode status) noexcept {
+    resp.success = false;
+    resp.status = status;
+}
 
 } // namespace Ipc

--- a/Common/include/SharedFrameBuffer.h
+++ b/Common/include/SharedFrameBuffer.h
@@ -2,9 +2,11 @@
 // SharedFrameBuffer: Cross-process shared memory for real-time frame push.
 // Created by EGoTouchService (writer, Session 0), opened by EGoTouchApp (reader, user session).
 
+#include <algorithm>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
-#include "SolverTypes.h"
+#include <cstring>
 #include "FrameLayout.h"
 
 #ifndef WIN32_LEAN_AND_MEAN
@@ -12,14 +14,26 @@
 #endif
 #include <windows.h>
 
-
-
 namespace Ipc {
 
 // Fixed shared memory name
 constexpr const wchar_t* kSharedFrameName = L"Global\\EGoTouchSharedFrame";
 // Frame-ready event name (Service signals after Write)
 constexpr const wchar_t* kFrameReadyEventName = L"Global\\EGoTouchFrameReady";
+
+// Stable shared-memory ABI contract for Phase 0.
+constexpr uint32_t kSharedFrameAbiVersion = 1;
+constexpr uint32_t kSharedFrameAbiCapabilities = 0;
+constexpr uint32_t kSharedFrameAbiReserved = 0;
+
+struct SharedFrameAbiHeader {
+    uint32_t abiVersion = kSharedFrameAbiVersion;
+    uint32_t totalSize = 0;
+    uint32_t headerSize = 0;
+    uint32_t capabilities = kSharedFrameAbiCapabilities;
+    uint32_t slotCount = 0;
+    uint32_t reserved = kSharedFrameAbiReserved;
+};
 
 // Maximum contacts in shared memory
 constexpr int kMaxSharedContacts = 10;
@@ -71,6 +85,48 @@ struct SharedStylusPacket {
     uint8_t reportId = 0x08;
     uint8_t length   = 13;
     uint8_t bytes[13]{};
+};
+
+// Common-owned POD diagnostics mirror for the shared-memory ABI.
+struct SharedStylusDiagnostics {
+    uint16_t anchorRow = 0;
+    uint16_t anchorCol = 0;
+    int32_t  rawDim1 = 0;
+    int32_t  rawDim2 = 0;
+    int32_t  finalDim1 = 0;
+    int32_t  finalDim2 = 0;
+    float    centerOff = 0.f;
+    float    pointX = 0.f;
+    float    pointY = 0.f;
+    bool     valid = false;
+    float    speedInstant = 0.f;
+    float    speedShortAvg = 0.f;
+    float    speedFullAvg = 0.f;
+    float    iirCoef = 0.f;
+    bool     isHover = false;
+    bool     isEdge = false;
+    float    tiltDiffX = 0.f;
+    float    tiltDiffY = 0.f;
+    uint16_t peakSignal = 0;
+    uint16_t rawPressure = 0;
+    uint16_t mappedPressure = 0;
+    uint32_t btSeq = 0;
+    uint8_t  predictedAgeFrames = 0;
+    bool     pressureIsReal = false;
+    uint8_t  vhfPenState = 0;
+    uint8_t  linearFilterState = 0;
+    uint16_t signalRatio = 0;
+    bool     exitSmoothed = false;
+    bool     cmfEnabled = false;
+    bool     coorReviserActive = false;
+    float    coorRevDeltaX = 0.f;
+    float    coorRevDeltaY = 0.f;
+    bool     tiltAnomalyDamped = false;
+    bool     sigSuppressActive = false;
+    uint8_t  penLifecycle = 0;
+    bool     wasInking = false;
+    int32_t  avg3PtDim1 = 0;
+    int32_t  avg3PtDim2 = 0;
 };
 
 // ───────────────────────────────────────────────────────────
@@ -142,14 +198,15 @@ struct SharedFrameData {
     bool     stylusNoPressInk = false;
     uint8_t  stylusPipelineStage = 0;  // 0=ok,1=slaveParse,2=tx1,3=peak,4=coord,5=noise
 
-    // ── Pipeline Diagnostics (same POD struct as StylusFrameData::StylusDiagnostics) ──
-    Solvers::StylusFrameData::StylusDiagnostics diag{};
+    // ── Pipeline Diagnostics (Common-owned shared-memory POD mirror) ──
+    SharedStylusDiagnostics diag{};
 
     // Structured suffix data — typed POD views over hardware status tables
     Frame::MasterSuffixView masterSuffix{};
     Frame::SlaveSuffixView  slaveSuffix{};
     bool     masterSuffixValid = false;
     bool     slaveSuffixValid  = false;
+    bool     masterWasRead = true;
 };
 
 // ─────────────────────────────────────────────────────────────
@@ -161,7 +218,16 @@ struct SharedFrameData {
 //
 // This eliminates the SeqLock retry loop entirely.
 struct SharedTripleBuffer {
-    static constexpr int kSlotCount = 3;
+    static constexpr uint32_t kSlotCount = 3;
+
+    SharedFrameAbiHeader abi{
+        .abiVersion = kSharedFrameAbiVersion,
+        .totalSize = sizeof(SharedTripleBuffer),
+        .headerSize = sizeof(SharedFrameAbiHeader),
+        .capabilities = kSharedFrameAbiCapabilities,
+        .slotCount = kSlotCount,
+        .reserved = kSharedFrameAbiReserved,
+    };
 
     // Control block (cache-line aligned atomics)
     alignas(64) std::atomic<uint32_t> readyIdx{0};    // latest complete slot for Reader
@@ -172,6 +238,338 @@ struct SharedTripleBuffer {
     // The three frame slots
     SharedFrameData slots[kSlotCount]{};
 };
+
+inline void ResetSharedFrameData(SharedFrameData& frame) noexcept {
+    frame = SharedFrameData{};
+}
+
+inline void CopySharedFrameData(SharedFrameData& dst, const SharedFrameData& src) noexcept {
+    if (&dst == &src) {
+        return;
+    }
+    std::memcpy(&dst, &src, sizeof(SharedFrameData));
+}
+
+template <typename HeatmapFrame>
+inline void PopulateSharedFrameDataFromSolverFrame(SharedFrameData& dst,
+                                                   const HeatmapFrame& src) {
+    ResetSharedFrameData(dst);
+    std::memcpy(dst.heatmapMatrix, src.heatmapMatrix, sizeof(dst.heatmapMatrix));
+    dst.timestamp = src.timestamp;
+    dst.masterWasRead = src.masterWasRead;
+
+#if EGOTOUCH_DIAG
+    std::memcpy(dst.touchZones, src.touchZones.data(), sizeof(dst.touchZones));
+    std::memcpy(dst.peakZones, src.peakZones.data(), sizeof(dst.peakZones));
+    const int numPeaks = std::min(static_cast<int>(src.peaks.size()), 30);
+    dst.peakCount = static_cast<uint8_t>(numPeaks);
+    for (int i = 0; i < numPeaks; ++i) {
+        dst.peaks[i].r = src.peaks[i].r;
+        dst.peaks[i].c = src.peaks[i].c;
+        dst.peaks[i].z = src.peaks[i].z;
+        dst.peaks[i].id = src.peaks[i].id;
+    }
+#endif
+
+    const int contactCount = std::min(static_cast<int>(src.contacts.size()), kMaxSharedContacts);
+    dst.contactCount = static_cast<uint8_t>(contactCount);
+    for (int i = 0; i < contactCount; ++i) {
+        const auto& srcContact = src.contacts[static_cast<size_t>(i)];
+        auto& dstContact = dst.contacts[i];
+        dstContact.id = srcContact.id;
+        dstContact.x = srcContact.x;
+        dstContact.y = srcContact.y;
+        dstContact.state = srcContact.state;
+        dstContact.area = srcContact.area;
+        dstContact.signalSum = srcContact.signalSum;
+        dstContact.sizeMm = srcContact.sizeMm;
+        dstContact.isEdge = srcContact.isEdge;
+        dstContact.isReported = srcContact.isReported;
+        dstContact.prevIndex = srcContact.prevIndex;
+        dstContact.debugFlags = srcContact.debugFlags;
+        dstContact.lifeFlags = srcContact.lifeFlags;
+        dstContact.reportFlags = srcContact.reportFlags;
+        dstContact.reportEvent = srcContact.reportEvent;
+    }
+
+    for (int i = 0; i < 2; ++i) {
+        dst.touchPackets[i].valid = src.touchPackets[i].valid;
+        dst.touchPackets[i].reportId = src.touchPackets[i].reportId;
+        dst.touchPackets[i].length = src.touchPackets[i].length;
+        std::memcpy(dst.touchPackets[i].bytes, src.touchPackets[i].bytes.data(), sizeof(dst.touchPackets[i].bytes));
+    }
+
+    const auto& srcPoint = src.stylus.point;
+    auto& dstPoint = dst.stylusPoint;
+    dstPoint.valid = srcPoint.valid;
+    dstPoint.x = srcPoint.x;
+    dstPoint.y = srcPoint.y;
+    dstPoint.reportX = srcPoint.reportX;
+    dstPoint.reportY = srcPoint.reportY;
+    dstPoint.pressure = srcPoint.pressure;
+    dstPoint.rawPressure = srcPoint.rawPressure;
+    dstPoint.mappedPressure = srcPoint.mappedPressure;
+    dstPoint.peakTx1 = srcPoint.peakTx1;
+    dstPoint.peakTx2 = srcPoint.peakTx2;
+    dstPoint.tiltValid = srcPoint.tiltValid;
+    dstPoint.preTiltX = srcPoint.preTiltX;
+    dstPoint.preTiltY = srcPoint.preTiltY;
+    dstPoint.tiltX = srcPoint.tiltX;
+    dstPoint.tiltY = srcPoint.tiltY;
+    dstPoint.tiltMagnitude = srcPoint.tiltMagnitude;
+    dstPoint.tiltAzimuthDeg = srcPoint.tiltAzimuthDeg;
+    dstPoint.tx1X = srcPoint.tx1X;
+    dstPoint.tx1Y = srcPoint.tx1Y;
+    dstPoint.tx2X = srcPoint.tx2X;
+    dstPoint.tx2Y = srcPoint.tx2Y;
+    dstPoint.confidence = srcPoint.confidence;
+
+    dst.stylusPacket.valid = src.stylus.packet.valid;
+    dst.stylusPacket.reportId = src.stylus.packet.reportId;
+    dst.stylusPacket.length = src.stylus.packet.length;
+    std::memcpy(dst.stylusPacket.bytes, src.stylus.packet.bytes.data(), sizeof(dst.stylusPacket.bytes));
+
+    const auto& stylus = src.stylus;
+    dst.stylusSlaveValid = stylus.slaveValid;
+    dst.stylusChecksumOk = stylus.checksumOk;
+    dst.stylusSlaveOffset = stylus.slaveWordOffset;
+    dst.stylusChecksum16 = stylus.checksum16;
+    dst.stylusTx1Valid = stylus.tx1BlockValid;
+    dst.stylusTx2Valid = stylus.tx2BlockValid;
+    dst.stylusStatus = stylus.status;
+    dst.stylusPressure = stylus.pressure;
+    dst.stylusAsaMode = stylus.asaMode;
+    dst.stylusDataType = stylus.dataType;
+    dst.stylusProcessResult = stylus.processResult;
+    dst.stylusValidJudgment = stylus.validJudgmentPassed;
+    dst.stylusRecheckEnabled = stylus.recheckEnabled;
+    dst.stylusRecheckPassed = stylus.recheckPassed;
+    dst.stylusRecheckOverlap = stylus.recheckOverlap;
+    dst.stylusRecheckThreshold = stylus.recheckThreshold;
+    dst.stylusHpp3NoiseInvalid = stylus.hpp3NoiseInvalid;
+    dst.stylusHpp3NoiseDebounce = stylus.hpp3NoiseDebounce;
+    dst.stylusHpp3Dim1Valid = stylus.hpp3Dim1SignalValid;
+    dst.stylusHpp3Dim2Valid = stylus.hpp3Dim2SignalValid;
+    dst.stylusHpp3WarnX = stylus.hpp3RatioWarnCountX;
+    dst.stylusHpp3WarnY = stylus.hpp3RatioWarnCountY;
+    dst.stylusHpp3AvgX = stylus.hpp3SignalAvgX;
+    dst.stylusHpp3AvgY = stylus.hpp3SignalAvgY;
+    dst.stylusHpp3Samples = stylus.hpp3SignalSampleCount;
+    dst.stylusTouchNullLike = stylus.touchNullLike;
+    dst.stylusTouchSuppressActive = stylus.touchSuppressActive;
+    dst.stylusTouchSuppressFrames = stylus.touchSuppressFrames;
+    dst.stylusSignalX = stylus.signalX;
+    dst.stylusSignalY = stylus.signalY;
+    dst.stylusMaxRawPeak = stylus.maxRawPeak;
+    dst.stylusNoPressInk = stylus.noPressInkActive;
+    dst.stylusPipelineStage = stylus.pipelineStage;
+
+    auto& diag = dst.diag;
+    const auto& srcDiag = stylus.diag;
+    diag.anchorRow = srcDiag.anchorRow;
+    diag.anchorCol = srcDiag.anchorCol;
+    diag.rawDim1 = srcDiag.rawDim1;
+    diag.rawDim2 = srcDiag.rawDim2;
+    diag.finalDim1 = srcDiag.finalDim1;
+    diag.finalDim2 = srcDiag.finalDim2;
+    diag.centerOff = srcDiag.centerOff;
+    diag.pointX = srcDiag.pointX;
+    diag.pointY = srcDiag.pointY;
+    diag.valid = srcDiag.valid;
+    diag.speedInstant = srcDiag.speedInstant;
+    diag.speedShortAvg = srcDiag.speedShortAvg;
+    diag.speedFullAvg = srcDiag.speedFullAvg;
+    diag.iirCoef = srcDiag.iirCoef;
+    diag.isHover = srcDiag.isHover;
+    diag.isEdge = srcDiag.isEdge;
+    diag.tiltDiffX = srcDiag.tiltDiffX;
+    diag.tiltDiffY = srcDiag.tiltDiffY;
+    diag.peakSignal = srcDiag.peakSignal;
+    diag.rawPressure = srcDiag.rawPressure;
+    diag.mappedPressure = srcDiag.mappedPressure;
+    diag.btSeq = srcDiag.btSeq;
+    diag.predictedAgeFrames = srcDiag.predictedAgeFrames;
+    diag.pressureIsReal = srcDiag.pressureIsReal;
+    diag.vhfPenState = srcDiag.vhfPenState;
+    diag.linearFilterState = srcDiag.linearFilterState;
+    diag.signalRatio = srcDiag.signalRatio;
+    diag.exitSmoothed = srcDiag.exitSmoothed;
+    diag.cmfEnabled = srcDiag.cmfEnabled;
+    diag.coorReviserActive = srcDiag.coorReviserActive;
+    diag.coorRevDeltaX = srcDiag.coorRevDeltaX;
+    diag.coorRevDeltaY = srcDiag.coorRevDeltaY;
+    diag.tiltAnomalyDamped = srcDiag.tiltAnomalyDamped;
+    diag.sigSuppressActive = srcDiag.sigSuppressActive;
+    diag.penLifecycle = srcDiag.penLifecycle;
+    diag.wasInking = srcDiag.wasInking;
+    diag.avg3PtDim1 = srcDiag.avg3PtDim1;
+    diag.avg3PtDim2 = srcDiag.avg3PtDim2;
+
+    dst.masterSuffix = src.masterSuffix;
+    dst.masterSuffixValid = src.masterSuffixValid;
+    dst.slaveSuffix = src.slaveSuffix;
+    dst.slaveSuffixValid = src.slaveSuffixValid;
+}
+
+template <typename HeatmapFrame>
+inline void PopulateSolverFrameFromSharedFrameData(HeatmapFrame& out,
+                                                   const SharedFrameData& src) {
+    std::memcpy(out.heatmapMatrix, src.heatmapMatrix, sizeof(out.heatmapMatrix));
+    out.timestamp = src.timestamp;
+    out.masterWasRead = src.masterWasRead;
+
+#if EGOTOUCH_DIAG
+    std::memcpy(out.touchZones.data(), src.touchZones, sizeof(src.touchZones));
+    std::memcpy(out.peakZones.data(), src.peakZones, sizeof(src.peakZones));
+    if (out.peaks.capacity() < 30) {
+        out.peaks.reserve(30);
+    }
+    out.peaks.resize(src.peakCount);
+    for (int i = 0; i < src.peakCount; ++i) {
+        out.peaks[static_cast<size_t>(i)] = {src.peaks[i].r, src.peaks[i].c, src.peaks[i].z, src.peaks[i].id};
+    }
+#endif
+
+    if (out.contacts.capacity() < kMaxSharedContacts) {
+        out.contacts.reserve(kMaxSharedContacts);
+    }
+    out.contacts.resize(src.contactCount);
+    for (int i = 0; i < src.contactCount; ++i) {
+        const auto& srcContact = src.contacts[i];
+        auto& dstContact = out.contacts[static_cast<size_t>(i)];
+        dstContact.id = srcContact.id;
+        dstContact.x = srcContact.x;
+        dstContact.y = srcContact.y;
+        dstContact.state = srcContact.state;
+        dstContact.area = srcContact.area;
+        dstContact.signalSum = srcContact.signalSum;
+        dstContact.sizeMm = srcContact.sizeMm;
+        dstContact.isEdge = srcContact.isEdge;
+        dstContact.isReported = srcContact.isReported;
+        dstContact.prevIndex = srcContact.prevIndex;
+        dstContact.debugFlags = srcContact.debugFlags;
+        dstContact.lifeFlags = srcContact.lifeFlags;
+        dstContact.reportFlags = srcContact.reportFlags;
+        dstContact.reportEvent = srcContact.reportEvent;
+    }
+
+    for (int i = 0; i < 2; ++i) {
+        out.touchPackets[i].valid = src.touchPackets[i].valid;
+        out.touchPackets[i].reportId = src.touchPackets[i].reportId;
+        out.touchPackets[i].length = src.touchPackets[i].length;
+        std::memcpy(out.touchPackets[i].bytes.data(), src.touchPackets[i].bytes, sizeof(src.touchPackets[i].bytes));
+    }
+
+    const auto& srcPoint = src.stylusPoint;
+    auto& dstPoint = out.stylus.point;
+    dstPoint.valid = srcPoint.valid;
+    dstPoint.x = srcPoint.x;
+    dstPoint.y = srcPoint.y;
+    dstPoint.reportX = srcPoint.reportX;
+    dstPoint.reportY = srcPoint.reportY;
+    dstPoint.pressure = srcPoint.pressure;
+    dstPoint.rawPressure = srcPoint.rawPressure;
+    dstPoint.mappedPressure = srcPoint.mappedPressure;
+    dstPoint.peakTx1 = srcPoint.peakTx1;
+    dstPoint.peakTx2 = srcPoint.peakTx2;
+    dstPoint.tiltValid = srcPoint.tiltValid;
+    dstPoint.preTiltX = srcPoint.preTiltX;
+    dstPoint.preTiltY = srcPoint.preTiltY;
+    dstPoint.tiltX = srcPoint.tiltX;
+    dstPoint.tiltY = srcPoint.tiltY;
+    dstPoint.tiltMagnitude = srcPoint.tiltMagnitude;
+    dstPoint.tiltAzimuthDeg = srcPoint.tiltAzimuthDeg;
+    dstPoint.tx1X = srcPoint.tx1X;
+    dstPoint.tx1Y = srcPoint.tx1Y;
+    dstPoint.tx2X = srcPoint.tx2X;
+    dstPoint.tx2Y = srcPoint.tx2Y;
+    dstPoint.confidence = srcPoint.confidence;
+
+    out.stylus.packet.valid = src.stylusPacket.valid;
+    out.stylus.packet.reportId = src.stylusPacket.reportId;
+    out.stylus.packet.length = src.stylusPacket.length;
+    std::memcpy(out.stylus.packet.bytes.data(), src.stylusPacket.bytes, sizeof(src.stylusPacket.bytes));
+
+    auto& stylus = out.stylus;
+    stylus.slaveValid = src.stylusSlaveValid;
+    stylus.checksumOk = src.stylusChecksumOk;
+    stylus.slaveWordOffset = src.stylusSlaveOffset;
+    stylus.checksum16 = src.stylusChecksum16;
+    stylus.tx1BlockValid = src.stylusTx1Valid;
+    stylus.tx2BlockValid = src.stylusTx2Valid;
+    stylus.status = src.stylusStatus;
+    stylus.pressure = src.stylusPressure;
+    stylus.asaMode = src.stylusAsaMode;
+    stylus.dataType = src.stylusDataType;
+    stylus.processResult = src.stylusProcessResult;
+    stylus.validJudgmentPassed = src.stylusValidJudgment;
+    stylus.recheckEnabled = src.stylusRecheckEnabled;
+    stylus.recheckPassed = src.stylusRecheckPassed;
+    stylus.recheckOverlap = src.stylusRecheckOverlap;
+    stylus.recheckThreshold = src.stylusRecheckThreshold;
+    stylus.hpp3NoiseInvalid = src.stylusHpp3NoiseInvalid;
+    stylus.hpp3NoiseDebounce = src.stylusHpp3NoiseDebounce;
+    stylus.hpp3Dim1SignalValid = src.stylusHpp3Dim1Valid;
+    stylus.hpp3Dim2SignalValid = src.stylusHpp3Dim2Valid;
+    stylus.hpp3RatioWarnCountX = src.stylusHpp3WarnX;
+    stylus.hpp3RatioWarnCountY = src.stylusHpp3WarnY;
+    stylus.hpp3SignalAvgX = src.stylusHpp3AvgX;
+    stylus.hpp3SignalAvgY = src.stylusHpp3AvgY;
+    stylus.hpp3SignalSampleCount = src.stylusHpp3Samples;
+    stylus.touchNullLike = src.stylusTouchNullLike;
+    stylus.touchSuppressActive = src.stylusTouchSuppressActive;
+    stylus.touchSuppressFrames = src.stylusTouchSuppressFrames;
+    stylus.signalX = src.stylusSignalX;
+    stylus.signalY = src.stylusSignalY;
+    stylus.maxRawPeak = src.stylusMaxRawPeak;
+    stylus.noPressInkActive = src.stylusNoPressInk;
+    stylus.pipelineStage = src.stylusPipelineStage;
+
+    auto& diag = stylus.diag;
+    diag.anchorRow = src.diag.anchorRow;
+    diag.anchorCol = src.diag.anchorCol;
+    diag.rawDim1 = src.diag.rawDim1;
+    diag.rawDim2 = src.diag.rawDim2;
+    diag.finalDim1 = src.diag.finalDim1;
+    diag.finalDim2 = src.diag.finalDim2;
+    diag.centerOff = src.diag.centerOff;
+    diag.pointX = src.diag.pointX;
+    diag.pointY = src.diag.pointY;
+    diag.valid = src.diag.valid;
+    diag.speedInstant = src.diag.speedInstant;
+    diag.speedShortAvg = src.diag.speedShortAvg;
+    diag.speedFullAvg = src.diag.speedFullAvg;
+    diag.iirCoef = src.diag.iirCoef;
+    diag.isHover = src.diag.isHover;
+    diag.isEdge = src.diag.isEdge;
+    diag.tiltDiffX = src.diag.tiltDiffX;
+    diag.tiltDiffY = src.diag.tiltDiffY;
+    diag.peakSignal = src.diag.peakSignal;
+    diag.rawPressure = src.diag.rawPressure;
+    diag.mappedPressure = src.diag.mappedPressure;
+    diag.btSeq = src.diag.btSeq;
+    diag.predictedAgeFrames = src.diag.predictedAgeFrames;
+    diag.pressureIsReal = src.diag.pressureIsReal;
+    diag.vhfPenState = src.diag.vhfPenState;
+    diag.linearFilterState = src.diag.linearFilterState;
+    diag.signalRatio = src.diag.signalRatio;
+    diag.exitSmoothed = src.diag.exitSmoothed;
+    diag.cmfEnabled = src.diag.cmfEnabled;
+    diag.coorReviserActive = src.diag.coorReviserActive;
+    diag.coorRevDeltaX = src.diag.coorRevDeltaX;
+    diag.coorRevDeltaY = src.diag.coorRevDeltaY;
+    diag.tiltAnomalyDamped = src.diag.tiltAnomalyDamped;
+    diag.sigSuppressActive = src.diag.sigSuppressActive;
+    diag.penLifecycle = src.diag.penLifecycle;
+    diag.wasInking = src.diag.wasInking;
+    diag.avg3PtDim1 = src.diag.avg3PtDim1;
+    diag.avg3PtDim2 = src.diag.avg3PtDim2;
+
+    out.masterSuffix = src.masterSuffix;
+    out.masterSuffixValid = src.masterSuffixValid;
+    out.slaveSuffix = src.slaveSuffix;
+    out.slaveSuffixValid = src.slaveSuffixValid;
+}
 
 // ───────────────────────────────────────────────────────────
 // Writer: used by EGoTouchService to push frame data
@@ -184,7 +582,7 @@ public:
 
     bool Open(const wchar_t* name);
     bool Create(const wchar_t* name);   // Service creates Global\ mapping
-    void Write(const Solvers::HeatmapFrame& frame);
+    void Write(const SharedFrameData& frame);
     void Close();
     bool IsOpen() const { return m_buf != nullptr; }
 
@@ -205,7 +603,16 @@ public:
 
     bool Create(const wchar_t* name);
     bool Open(const wchar_t* name);     // App opens existing mapping
-    bool Read(Solvers::HeatmapFrame& out);
+    bool Read(SharedFrameData& out);
+    template <typename HeatmapFrame>
+    bool Read(HeatmapFrame& out) {
+        SharedFrameData frame{};
+        if (!Read(frame)) {
+            return false;
+        }
+        PopulateSolverFrameFromSharedFrameData(out, frame);
+        return true;
+    }
     uint64_t LastFrameId() const;
     uint64_t LastSlaveFrameId() const;
     uint64_t LastMasterFrameId() const;

--- a/Common/source/IpcPipeClient.cpp
+++ b/Common/source/IpcPipeClient.cpp
@@ -99,4 +99,22 @@ IpcResponse IpcPipeClient::SaveConfig() {
     return Send(req);
 }
 
+IpcResponse IpcPipeClient::GetConfigSnapshot() {
+    IpcRequest req{}; req.command = IpcCommand::GetConfigSnapshot;
+    return Send(req);
+}
+
+IpcResponse IpcPipeClient::ApplyConfigPatch(const ApplyConfigPatchRequestWire& patch) {
+    IpcRequest req{};
+    req.command = IpcCommand::ApplyConfigPatch;
+    req.paramLen = static_cast<uint16_t>(sizeof(patch));
+    std::memcpy(req.param, &patch, sizeof(patch));
+    return Send(req);
+}
+
+IpcResponse IpcPipeClient::PersistConfig() {
+    IpcRequest req{}; req.command = IpcCommand::PersistConfig;
+    return Send(req);
+}
+
 } // namespace Ipc

--- a/Common/source/SharedFrameBuffer.cpp
+++ b/Common/source/SharedFrameBuffer.cpp
@@ -1,7 +1,5 @@
 #include "SharedFrameBuffer.h"
-#include "SolverTypes.h"
 #include "Logger.h"
-#include <algorithm>
 #include <cstring>
 #include <sddl.h>
 
@@ -11,6 +9,22 @@ namespace {
 
 constexpr LPCWSTR kIpcObjectSddl =
     L"D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;IU)";
+
+void InitializeAbiHeader(SharedTripleBuffer& buffer) noexcept {
+    buffer.abi.abiVersion = kSharedFrameAbiVersion;
+    buffer.abi.totalSize = sizeof(SharedTripleBuffer);
+    buffer.abi.headerSize = sizeof(SharedFrameAbiHeader);
+    buffer.abi.capabilities = kSharedFrameAbiCapabilities;
+    buffer.abi.slotCount = SharedTripleBuffer::kSlotCount;
+    buffer.abi.reserved = kSharedFrameAbiReserved;
+}
+
+bool HasCompatibleAbi(const SharedTripleBuffer& buffer) noexcept {
+    return buffer.abi.abiVersion == kSharedFrameAbiVersion &&
+           buffer.abi.totalSize == sizeof(SharedTripleBuffer) &&
+           buffer.abi.headerSize == sizeof(SharedFrameAbiHeader) &&
+           buffer.abi.slotCount == SharedTripleBuffer::kSlotCount;
+}
 
 struct ScopedSecurityDescriptor {
     PSECURITY_DESCRIPTOR value = nullptr;
@@ -52,6 +66,15 @@ bool SharedFrameWriter::Open(const wchar_t* name) {
         m_mapHandle = nullptr;
         return false;
     }
+    if (!HasCompatibleAbi(*m_buf)) {
+        LOG_ERROR("Common", __func__, "IPC", "Shared memory ABI mismatch: version={} totalSize={} headerSize={} slotCount={}",
+                  m_buf->abi.abiVersion, m_buf->abi.totalSize, m_buf->abi.headerSize, m_buf->abi.slotCount);
+        UnmapViewOfFile(m_buf);
+        m_buf = nullptr;
+        CloseHandle(m_mapHandle);
+        m_mapHandle = nullptr;
+        return false;
+    }
     m_writeIdx = 1;  // Start writing to slot 1 (slot 0 is initial readyIdx)
     LOG_INFO("Common", __func__, "IPC", "Shared memory opened for writing.");
 
@@ -89,6 +112,7 @@ bool SharedFrameWriter::Create(const wchar_t* name) {
         return false;
     }
     std::memset(m_buf, 0, sizeof(SharedTripleBuffer));
+    InitializeAbiHeader(*m_buf);
     m_writeIdx = 1;
     LOG_INFO("Common", __func__, "IPC", "Shared memory created for writing ({} bytes, 3 slots).",  sizeof(SharedTripleBuffer));
 
@@ -100,141 +124,19 @@ bool SharedFrameWriter::Create(const wchar_t* name) {
     return true;
 }
 
-void SharedFrameWriter::Write(const Solvers::HeatmapFrame& frame) {
+void SharedFrameWriter::Write(const SharedFrameData& frame) {
     if (!m_buf) return;
 
-    // Triple-buffer: write to slots[m_writeIdx] — Reader never touches this slot
     SharedFrameData* m_data = &m_buf->slots[m_writeIdx];
+    CopySharedFrameData(*m_data, frame);
 
-    // Copy heatmap
-    std::memcpy(m_data->heatmapMatrix, frame.heatmapMatrix,
-                sizeof(frame.heatmapMatrix));
-    m_data->timestamp = frame.timestamp;
-
-    // Copy zones & peaks
-#if EGOTOUCH_DIAG
-    std::memcpy(m_data->touchZones, frame.touchZones.data(), sizeof(m_data->touchZones));
-    std::memcpy(m_data->peakZones, frame.peakZones.data(), sizeof(m_data->peakZones));
-    const int numPeaks = std::min(static_cast<int>(frame.peaks.size()), 30);
-    m_data->peakCount = static_cast<uint8_t>(numPeaks);
-    for (int i = 0; i < numPeaks; ++i) {
-        m_data->peaks[i].r = frame.peaks[i].r;
-        m_data->peaks[i].c = frame.peaks[i].c;
-        m_data->peaks[i].z = frame.peaks[i].z;
-        m_data->peaks[i].id = frame.peaks[i].id;
-    }
-#else
-    std::memset(m_data->touchZones, 0, sizeof(m_data->touchZones));
-    std::memset(m_data->peakZones, 0, sizeof(m_data->peakZones));
-    m_data->peakCount = 0;
-#endif
-
-    // Copy contacts (flatten vector → fixed array)
-    const int n = std::min(static_cast<int>(frame.contacts.size()),
-                           kMaxSharedContacts);
-    m_data->contactCount = static_cast<uint8_t>(n);
-    for (int i = 0; i < n; ++i) {
-        const auto& src = frame.contacts[i];
-        auto& dst = m_data->contacts[i];
-        dst.id = src.id; dst.x = src.x; dst.y = src.y;
-        dst.state = src.state; dst.area = src.area;
-        dst.signalSum = src.signalSum; dst.sizeMm = src.sizeMm;
-        dst.isEdge = src.isEdge; dst.isReported = src.isReported;
-        dst.prevIndex = src.prevIndex; dst.debugFlags = src.debugFlags;
-        dst.lifeFlags = src.lifeFlags; dst.reportFlags = src.reportFlags;
-        dst.reportEvent = src.reportEvent;
-    }
-
-    // Touch packets
-    for (int i = 0; i < 2; ++i) {
-        m_data->touchPackets[i].valid = frame.touchPackets[i].valid;
-        m_data->touchPackets[i].reportId = frame.touchPackets[i].reportId;
-        m_data->touchPackets[i].length = frame.touchPackets[i].length;
-        std::memcpy(m_data->touchPackets[i].bytes,
-                    frame.touchPackets[i].bytes.data(), 32);
-    }
-
-    // Stylus point
-    const auto& sp = frame.stylus.point;
-    auto& dp = m_data->stylusPoint;
-    dp.valid = sp.valid; dp.x = sp.x; dp.y = sp.y;
-    dp.reportX = sp.reportX; dp.reportY = sp.reportY;
-    dp.pressure = sp.pressure; dp.rawPressure = sp.rawPressure;
-    dp.mappedPressure = sp.mappedPressure;
-    dp.peakTx1 = sp.peakTx1; dp.peakTx2 = sp.peakTx2;
-    dp.tiltValid = sp.tiltValid;
-    dp.preTiltX = sp.preTiltX; dp.preTiltY = sp.preTiltY;
-    dp.tiltX = sp.tiltX; dp.tiltY = sp.tiltY;
-    dp.tiltMagnitude = sp.tiltMagnitude;
-    dp.tiltAzimuthDeg = sp.tiltAzimuthDeg;
-    dp.tx1X = sp.tx1X; dp.tx1Y = sp.tx1Y;
-    dp.tx2X = sp.tx2X; dp.tx2Y = sp.tx2Y;
-    dp.confidence = sp.confidence;
-
-    // Stylus packet
-    m_data->stylusPacket.valid = frame.stylus.packet.valid;
-    m_data->stylusPacket.reportId = frame.stylus.packet.reportId;
-    m_data->stylusPacket.length = frame.stylus.packet.length;
-    std::memcpy(m_data->stylusPacket.bytes,
-                frame.stylus.packet.bytes.data(), 13);
-
-    // Stylus debug fields
-    const auto& s = frame.stylus;
-    m_data->stylusSlaveValid = s.slaveValid;
-    m_data->stylusChecksumOk = s.checksumOk;
-    m_data->stylusSlaveOffset = s.slaveWordOffset;
-    m_data->stylusChecksum16 = s.checksum16;
-    m_data->stylusTx1Valid = s.tx1BlockValid;
-    m_data->stylusTx2Valid = s.tx2BlockValid;
-    m_data->stylusStatus = s.status;
-    m_data->stylusPressure = s.pressure;
-    m_data->stylusAsaMode = s.asaMode;
-    m_data->stylusDataType = s.dataType;
-    m_data->stylusProcessResult = s.processResult;
-    m_data->stylusValidJudgment = s.validJudgmentPassed;
-    m_data->stylusRecheckEnabled = s.recheckEnabled;
-    m_data->stylusRecheckPassed = s.recheckPassed;
-    m_data->stylusRecheckOverlap = s.recheckOverlap;
-    m_data->stylusRecheckThreshold = s.recheckThreshold;
-    m_data->stylusHpp3NoiseInvalid = s.hpp3NoiseInvalid;
-    m_data->stylusHpp3NoiseDebounce = s.hpp3NoiseDebounce;
-    m_data->stylusHpp3Dim1Valid = s.hpp3Dim1SignalValid;
-    m_data->stylusHpp3Dim2Valid = s.hpp3Dim2SignalValid;
-    m_data->stylusHpp3WarnX = s.hpp3RatioWarnCountX;
-    m_data->stylusHpp3WarnY = s.hpp3RatioWarnCountY;
-    m_data->stylusHpp3AvgX = s.hpp3SignalAvgX;
-    m_data->stylusHpp3AvgY = s.hpp3SignalAvgY;
-    m_data->stylusHpp3Samples = s.hpp3SignalSampleCount;
-    m_data->stylusTouchNullLike = s.touchNullLike;
-    m_data->stylusTouchSuppressActive = s.touchSuppressActive;
-    m_data->stylusTouchSuppressFrames = s.touchSuppressFrames;
-    m_data->stylusSignalX = s.signalX;
-    m_data->stylusSignalY = s.signalY;
-    m_data->stylusMaxRawPeak = s.maxRawPeak;
-    m_data->stylusNoPressInk = s.noPressInkActive;
-    m_data->stylusPipelineStage = s.pipelineStage;
-    // Pipeline diagnostics (single copy)
-    m_data->diag = s.diag;
-
-    // Structured suffix data — copy from frame (populated by MasterFrameParser)
-    m_data->masterSuffix = frame.masterSuffix;
-    m_data->masterSuffixValid = frame.masterSuffixValid;
-    m_data->slaveSuffix = frame.slaveSuffix;
-    m_data->slaveSuffixValid = frame.slaveSuffixValid;
-
-    // Triple-buffer: publish this slot and advance to next free slot
-    //   readyIdx = m_writeIdx  (Reader sees this slot next)
-    //   m_writeIdx = next slot that is neither ready nor being read
     const uint32_t justWritten = m_writeIdx;
     m_buf->readyIdx.store(justWritten, std::memory_order_release);
-    // Pick next write slot: cycle through 0→1→2→0... skipping readyIdx
     m_writeIdx = (justWritten + 1) % SharedTripleBuffer::kSlotCount;
-    // If we landed on readyIdx, skip to next (Reader might be reading readyIdx)
     if (m_writeIdx == m_buf->readyIdx.load(std::memory_order_relaxed)) {
         m_writeIdx = (m_writeIdx + 1) % SharedTripleBuffer::kSlotCount;
     }
 
-    // Increment frame IDs
     m_buf->frameId.fetch_add(1, std::memory_order_relaxed);
     m_buf->slaveFrameId.fetch_add(1, std::memory_order_relaxed);
     if (frame.masterWasRead) {
@@ -289,6 +191,7 @@ bool SharedFrameReader::Create(const wchar_t* name) {
     }
     // Zero-initialize
     std::memset(m_buf, 0, sizeof(SharedTripleBuffer));
+    InitializeAbiHeader(*m_buf);
     LOG_INFO("Common", __func__, "IPC", "Shared memory created ({} bytes, 3 slots).",  sizeof(SharedTripleBuffer));
 
     // Create frame-ready event (auto-reset)
@@ -314,6 +217,15 @@ bool SharedFrameReader::Open(const wchar_t* name) {
         m_mapHandle = nullptr;
         return false;
     }
+    if (!HasCompatibleAbi(*m_buf)) {
+        LOG_ERROR("Common", __func__, "IPC", "Shared memory ABI mismatch: version={} totalSize={} headerSize={} slotCount={}",
+                  m_buf->abi.abiVersion, m_buf->abi.totalSize, m_buf->abi.headerSize, m_buf->abi.slotCount);
+        UnmapViewOfFile(m_buf);
+        m_buf = nullptr;
+        CloseHandle(m_mapHandle);
+        m_mapHandle = nullptr;
+        return false;
+    }
     m_lastReadId = 0;
     LOG_INFO("Common", __func__, "IPC", "Shared memory opened for reading.");
 
@@ -325,127 +237,14 @@ bool SharedFrameReader::Open(const wchar_t* name) {
     return true;
 }
 
-bool SharedFrameReader::Read(Solvers::HeatmapFrame& out) {
+bool SharedFrameReader::Read(SharedFrameData& out) {
     if (!m_buf) return false;
 
-    // Triple-buffer: simply read from slots[readyIdx] — no retry needed
     const uint64_t currentId = m_buf->frameId.load(std::memory_order_acquire);
-    if (currentId == m_lastReadId) return false; // no new frame
+    if (currentId == m_lastReadId) return false;
 
     const uint32_t idx = m_buf->readyIdx.load(std::memory_order_acquire);
-    const SharedFrameData* m_data = &m_buf->slots[idx];
-
-    // Copy heatmap
-    std::memcpy(out.heatmapMatrix, m_data->heatmapMatrix,
-                sizeof(out.heatmapMatrix));
-    out.timestamp = m_data->timestamp;
-
-    // Restore zones & peaks
-#if EGOTOUCH_DIAG
-    std::memcpy(out.touchZones.data(), m_data->touchZones, sizeof(m_data->touchZones));
-    std::memcpy(out.peakZones.data(), m_data->peakZones, sizeof(m_data->peakZones));
-    if (out.peaks.capacity() < 30) {
-        out.peaks.reserve(30);
-    }
-    out.peaks.resize(m_data->peakCount);
-    for (int i = 0; i < m_data->peakCount; ++i) {
-        out.peaks[static_cast<size_t>(i)] = {m_data->peaks[i].r, m_data->peaks[i].c, m_data->peaks[i].z, m_data->peaks[i].id};
-    }
-#endif
-
-    // Copy contacts
-    if (out.contacts.capacity() < kMaxSharedContacts) {
-        out.contacts.reserve(kMaxSharedContacts);
-    }
-    out.contacts.resize(m_data->contactCount);
-    for (int i = 0; i < m_data->contactCount; ++i) {
-        const auto& src = m_data->contacts[i];
-        auto& dst = out.contacts[i];
-        dst.id = src.id; dst.x = src.x; dst.y = src.y;
-        dst.state = src.state; dst.area = src.area;
-        dst.signalSum = src.signalSum; dst.sizeMm = src.sizeMm;
-        dst.isEdge = src.isEdge; dst.isReported = src.isReported;
-        dst.prevIndex = src.prevIndex; dst.debugFlags = src.debugFlags;
-        dst.lifeFlags = src.lifeFlags; dst.reportFlags = src.reportFlags;
-        dst.reportEvent = src.reportEvent;
-    }
-
-    // Touch packets
-    for (int i = 0; i < 2; ++i) {
-        out.touchPackets[i].valid = m_data->touchPackets[i].valid;
-        out.touchPackets[i].reportId = m_data->touchPackets[i].reportId;
-        out.touchPackets[i].length = m_data->touchPackets[i].length;
-        std::memcpy(out.touchPackets[i].bytes.data(),
-                    m_data->touchPackets[i].bytes, 32);
-    }
-
-    // Stylus point → StylusFrameData.point
-    const auto& spt = m_data->stylusPoint;
-    auto& dpt = out.stylus.point;
-    dpt.valid = spt.valid; dpt.x = spt.x; dpt.y = spt.y;
-    dpt.reportX = spt.reportX; dpt.reportY = spt.reportY;
-    dpt.pressure = spt.pressure; dpt.rawPressure = spt.rawPressure;
-    dpt.mappedPressure = spt.mappedPressure;
-    dpt.peakTx1 = spt.peakTx1; dpt.peakTx2 = spt.peakTx2;
-    dpt.tiltValid = spt.tiltValid;
-    dpt.preTiltX = spt.preTiltX; dpt.preTiltY = spt.preTiltY;
-    dpt.tiltX = spt.tiltX; dpt.tiltY = spt.tiltY;
-    dpt.tiltMagnitude = spt.tiltMagnitude;
-    dpt.tiltAzimuthDeg = spt.tiltAzimuthDeg;
-    dpt.tx1X = spt.tx1X; dpt.tx1Y = spt.tx1Y;
-    dpt.tx2X = spt.tx2X; dpt.tx2Y = spt.tx2Y;
-    dpt.confidence = spt.confidence;
-
-    // Stylus packet
-    out.stylus.packet.valid = m_data->stylusPacket.valid;
-    out.stylus.packet.reportId = m_data->stylusPacket.reportId;
-    out.stylus.packet.length = m_data->stylusPacket.length;
-    std::memcpy(out.stylus.packet.bytes.data(),
-                m_data->stylusPacket.bytes, 13);
-
-    // Stylus debug fields
-    auto& os = out.stylus;
-    os.slaveValid = m_data->stylusSlaveValid;
-    os.checksumOk = m_data->stylusChecksumOk;
-    os.slaveWordOffset = m_data->stylusSlaveOffset;
-    os.checksum16 = m_data->stylusChecksum16;
-    os.tx1BlockValid = m_data->stylusTx1Valid;
-    os.tx2BlockValid = m_data->stylusTx2Valid;
-    os.status = m_data->stylusStatus;
-    os.pressure = m_data->stylusPressure;
-    os.asaMode = m_data->stylusAsaMode;
-    os.dataType = m_data->stylusDataType;
-    os.processResult = m_data->stylusProcessResult;
-    os.validJudgmentPassed = m_data->stylusValidJudgment;
-    os.recheckEnabled = m_data->stylusRecheckEnabled;
-    os.recheckPassed = m_data->stylusRecheckPassed;
-    os.recheckOverlap = m_data->stylusRecheckOverlap;
-    os.recheckThreshold = m_data->stylusRecheckThreshold;
-    os.hpp3NoiseInvalid = m_data->stylusHpp3NoiseInvalid;
-    os.hpp3NoiseDebounce = m_data->stylusHpp3NoiseDebounce;
-    os.hpp3Dim1SignalValid = m_data->stylusHpp3Dim1Valid;
-    os.hpp3Dim2SignalValid = m_data->stylusHpp3Dim2Valid;
-    os.hpp3RatioWarnCountX = m_data->stylusHpp3WarnX;
-    os.hpp3RatioWarnCountY = m_data->stylusHpp3WarnY;
-    os.hpp3SignalAvgX = m_data->stylusHpp3AvgX;
-    os.hpp3SignalAvgY = m_data->stylusHpp3AvgY;
-    os.hpp3SignalSampleCount = m_data->stylusHpp3Samples;
-    os.touchNullLike = m_data->stylusTouchNullLike;
-    os.touchSuppressActive = m_data->stylusTouchSuppressActive;
-    os.touchSuppressFrames = m_data->stylusTouchSuppressFrames;
-    os.signalX = m_data->stylusSignalX;
-    os.signalY = m_data->stylusSignalY;
-    os.maxRawPeak = m_data->stylusMaxRawPeak;
-    os.noPressInkActive = m_data->stylusNoPressInk;
-    os.pipelineStage = m_data->stylusPipelineStage;
-    // Pipeline diagnostics (single copy)
-    os.diag = m_data->diag;
-
-    // Structured suffix — copy typed views directly
-    out.masterSuffix = m_data->masterSuffix;
-    out.masterSuffixValid = m_data->masterSuffixValid;
-    out.slaveSuffix = m_data->slaveSuffix;
-    out.slaveSuffixValid = m_data->slaveSuffixValid;
+    CopySharedFrameData(out, m_buf->slots[idx]);
 
     m_lastReadId = currentId;
     return true;

--- a/EGoTouchService/Device/runtime/DeviceRuntime.cpp
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.cpp
@@ -2,7 +2,13 @@
 #include "SolverTypes.h"
 #include "Logger.h"
 
+#include <chrono>
+#include <cstdio>
 #include <format>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
 
 namespace {
 constexpr std::size_t kMaxHistoryItems = 512;
@@ -27,6 +33,18 @@ const char* ToString(CommandSource s) noexcept {
     case CommandSource::External:     return "External";
     case CommandSource::SystemPolicy: return "SystemPolicy";
     default:                          return "Unknown";
+    }
+}
+
+const char* ToString(RuntimePolicyEvent::Type type) noexcept {
+    switch (type) {
+    case RuntimePolicyEvent::Type::DisplayOn:        return "DisplayOn";
+    case RuntimePolicyEvent::Type::DisplayOff:       return "DisplayOff";
+    case RuntimePolicyEvent::Type::LidOn:            return "LidOn";
+    case RuntimePolicyEvent::Type::LidOff:           return "LidOff";
+    case RuntimePolicyEvent::Type::Shutdown:         return "Shutdown";
+    case RuntimePolicyEvent::Type::ResumeAutomatic:  return "ResumeAutomatic";
+    default:                                         return "Unknown";
     }
 }
 
@@ -60,6 +78,26 @@ void DeviceRuntime::Stop() {
     m_lastNote = "Runtime stopped";
 }
 
+DeviceRuntime::StartRequestResult DeviceRuntime::RequestStart() {
+    if (IsRunning()) {
+        return StartRequestResult::AlreadyRunning;
+    }
+    return Start() ? StartRequestResult::Started : StartRequestResult::Failed;
+}
+
+DeviceRuntime::StopRequestResult DeviceRuntime::RequestStop() {
+    if (!IsRunning()) {
+        return StopRequestResult::AlreadyStopped;
+    }
+    Stop();
+    return StopRequestResult::Stopped;
+}
+
+void DeviceRuntime::ApplyServicePolicy(bool autoMode, bool stylusVhfEnabled) {
+    SetAutoMode(autoMode);
+    SetStylusVhfEnabled(stylusVhfEnabled);
+}
+
 bool DeviceRuntime::IsShutdownRequested() const {
     return m_stopReason.load() == StopReason::Shutdown;
 }
@@ -71,7 +109,47 @@ void DeviceRuntime::SetFramePushCallback(DeviceRuntime::FramePushCallback cb) {
 }
 #endif
 
+void DeviceRuntime::LoadPipelineConfig(const std::string& key, const std::string& value) {
+    m_touchPipeline.LoadConfig(key, value);
+}
+
+void DeviceRuntime::LoadStylusPipelineConfig(const std::string& key, const std::string& value) {
+    m_stylusPipeline.LoadConfig(key, value);
+}
+
+void DeviceRuntime::SavePipelineConfig(std::ostream& out) const {
+    m_touchPipeline.SaveConfig(out);
+}
+
+void DeviceRuntime::SaveStylusPipelineConfig(std::ostream& out) const {
+    m_stylusPipeline.SaveConfig(out);
+}
+
+void DeviceRuntime::SetVhfEnabled(bool enabled) {
+    m_vhfReporter.SetEnabled(enabled);
+}
+
+void DeviceRuntime::SetVhfTransposeEnabled(bool enabled) {
+    m_vhfReporter.SetTransposeEnabled(enabled);
+}
+
+void DeviceRuntime::IngestBtMcuPressure(uint16_t p) {
+    m_stylusPipeline.SetBtMcuPressure(p);
+}
+
 // --------------- 命令注入 ---------------
+
+bool DeviceRuntime::SubmitExternalAfeCommand(AFE_Command type, uint8_t param) {
+    if (!m_running.load(std::memory_order_acquire)) {
+        return false;
+    }
+
+    command cmd{};
+    cmd.type = type;
+    cmd.param = param;
+    SubmitCommand(cmd, CommandSource::External, "IPC AFE");
+    return true;
+}
 
 uint64_t DeviceRuntime::SubmitCommand(
         command cmd, CommandSource src, const char* reason) {
@@ -88,43 +166,47 @@ uint64_t DeviceRuntime::SubmitCommand(
     return qc.id;
 }
 
-void DeviceRuntime::IngestSystemEvent(
-        const Host::SystemStateEvent& ev) {
+void DeviceRuntime::IngestPolicyEvent(
+        const RuntimePolicyEvent& ev) {
     const auto now = std::chrono::steady_clock::now();
     {
         std::lock_guard<std::mutex> lk(m_mu);
-        int key = static_cast<int>(ev.type);
+        const int key = static_cast<int>(ev.type);
         auto it = m_lastEventByType.find(key);
         if (it != m_lastEventByType.end() &&
             now - it->second < kEventDebounce) return;
         m_lastEventByType[key] = now;
     }
-    using ET = Host::SystemStateEventType;
+
+    using EventType = RuntimePolicyEvent::Type;
     switch (ev.type) {
-    case ET::DisplayOff:
-    case ET::LidOff:
-        LOG_INFO("Runtime", __func__, "Policy", "Sleep event ({}), requesting suspend.", Host::ToString(ev.type));
+    case EventType::DisplayOff:
+    case EventType::LidOff:
+        LOG_INFO("Runtime", __func__, "Policy", "Sleep event ({}), requesting suspend.", ToString(ev.type));
         m_chip.CancelPendingFrameRead();  // abort any blocking GetFrame NOW
         m_stopReason.store(StopReason::ScreenOff);
         break;
-    case ET::DisplayOn:
-    case ET::LidOn:
-    case ET::ResumeAutomatic:
-        LOG_INFO("Runtime", __func__, "Policy", "Wake event ({}), attempting resume.", Host::ToString(ev.type));
+    case EventType::DisplayOn:
+    case EventType::LidOn:
+    case EventType::ResumeAutomatic:
+        LOG_INFO("Runtime", __func__, "Policy", "Wake event ({}), attempting resume.", ToString(ev.type));
         // suspend 状态下直接恢复，无需重建线程
         if (m_state.load() == workerState::suspend) {
             SetState(workerState::ready);
             LOG_INFO("Runtime", __func__, "Policy", "Resumed from suspend -> ready (zero-cost wakeup).");
-        } else {
+        } else if (IsRunning()) {
             Stop();
             Start();
+        } else {
+            LOG_INFO("Runtime", __func__, "Policy", "Wake event ignored because runtime is stopped.");
         }
         break;
-    case ET::Shutdown:
+    case EventType::Shutdown:
         LOG_INFO("Runtime", __func__, "Policy", "Shutdown event, requesting termination.");
         m_stopReason.store(StopReason::Shutdown);
         break;
-    default: break;
+    default:
+        break;
     }
 }
 
@@ -312,7 +394,7 @@ void DeviceRuntime::OnStreaming() {
 
 // --------------- MCU 事件路由 ---------------
 
-void DeviceRuntime::OnPenEvent(const Himax::Pen::PenEvent& ev) {
+void DeviceRuntime::IngestPenEvent(const Himax::Pen::PenEvent& ev) {
     using EC = Himax::Pen::PenUsbEventCode;
     switch (ev.code) {
 

--- a/EGoTouchService/Device/runtime/DeviceRuntime.h
+++ b/EGoTouchService/Device/runtime/DeviceRuntime.h
@@ -6,6 +6,7 @@
 
 #include <deque>
 #include <expected>
+#include <iosfwd>
 #include <mutex>
 
 #include <string>
@@ -16,7 +17,6 @@
 #include "btmcu/PenUsbTypes.h"
 
 #include "himax/HimaxChip.h"
-#include "SystemStateEvent.h"
 #include "TouchSolver/TouchPipeline.h"
 #include "vhf/VhfReporter.h"
 #include "StylusSolver/StylusPipeline.h"
@@ -49,6 +49,31 @@ enum class CommandSource : uint8_t {
 };
 
 const char* ToString(CommandSource s) noexcept;
+
+class RuntimePolicyEvent {
+public:
+    enum class Type : uint8_t {
+        Unknown = 0,
+        DisplayOn,
+        DisplayOff,
+        LidOn,
+        LidOff,
+        Shutdown,
+        ResumeAutomatic,
+    };
+
+    enum class Source : uint8_t {
+        HostSystemState = 0,
+    };
+
+    Type type = Type::Unknown;
+    Source source = Source::HostSystemState;
+    std::chrono::system_clock::time_point timestamp{};
+    uint32_t rawIndex = 0;
+};
+
+const char* ToString(RuntimePolicyEvent::Type type) noexcept;
+
 // --------------- 审计日志 ---------------
 
 struct HistoryEntry {
@@ -88,6 +113,17 @@ struct RuntimePenState {
 
 class DeviceRuntime {
 public:
+    enum class StartRequestResult : uint8_t {
+        Started = 0,
+        AlreadyRunning,
+        Failed,
+    };
+
+    enum class StopRequestResult : uint8_t {
+        Stopped = 0,
+        AlreadyStopped,
+    };
+
     DeviceRuntime(const std::wstring& master,
                   const std::wstring& slave,
                   const std::wstring& interrupt);
@@ -97,6 +133,8 @@ public:
 
     bool Start();
     void Stop();
+    StartRequestResult RequestStart();
+    StopRequestResult RequestStop();
     bool IsShutdownRequested() const;
     bool IsRunning() const { return m_running.load(); }
     bool IsSuspended() const { return m_state.load() == workerState::suspend; }
@@ -109,16 +147,18 @@ public:
     // 单独的 Stylus VHF 输出开关
     void SetStylusVhfEnabled(bool v) { m_stylusVhfEnabled.store(v); }
     bool IsStylusVhfEnabled() const { return m_stylusVhfEnabled.load(); }
+    void ApplyServicePolicy(bool autoMode, bool stylusVhfEnabled);
 
-    // Pipeline / VHF 配置 — 仅在 Start() 前调用
-    Solvers::TouchPipeline& GetTouchPipeline() { return m_touchPipeline; }
-    // Legacy alias
-    Solvers::TouchPipeline& GetPipeline() { return m_touchPipeline; }
-    Solvers::StylusPipeline& GetStylusPipeline() { return m_stylusPipeline; }
-    VhfReporter& GetVhfReporter() { return m_vhfReporter; }
+    // Pipeline/VHF façade methods for Phase 0 contract freeze.
+    void LoadPipelineConfig(const std::string& key, const std::string& value);
+    void LoadStylusPipelineConfig(const std::string& key, const std::string& value);
+    void SavePipelineConfig(std::ostream& out) const;
+    void SaveStylusPipelineConfig(std::ostream& out) const;
+    void SetVhfEnabled(bool enabled);
+    void SetVhfTransposeEnabled(bool enabled);
 
     /// 注入 BT MCU 压感值（由 PenBridge 线程写入，StylusPipeline 帧内读取）
-    void SetBtMcuPressure(uint16_t p) { m_stylusPipeline.SetBtMcuPressure(p); }
+    void IngestBtMcuPressure(uint16_t p);
 
     // Frame push callback for IPC (called after pipeline+VHF in worker loop)
     using FramePushCallback = std::function<void(const Solvers::HeatmapFrame&)>;
@@ -126,7 +166,8 @@ public:
     void SetFramePushCallback(FramePushCallback cb);
 #endif
 
-    void IngestSystemEvent(const Host::SystemStateEvent& ev);
+    void IngestPolicyEvent(const RuntimePolicyEvent& ev);
+    bool SubmitExternalAfeCommand(AFE_Command type, uint8_t param);
     uint64_t SubmitCommand(command cmd, CommandSource src,
                            const char* reason = "");
 
@@ -134,8 +175,8 @@ public:
     std::vector<HistoryEntry> GetHistory(std::size_t n = 200) const;
     void ClearHistory();
 
-    /// MCU 事件 → AFE 命令分派（从 ServiceHost 迁移到设备层）
-    void OnPenEvent(const Himax::Pen::PenEvent& ev);
+    /// MCU 事件 ingress（runtime 内部完成状态/AFE 命令分派）
+    void IngestPenEvent(const Himax::Pen::PenEvent& ev);
 
 private:
     ThreadResult WorkerMain();

--- a/EGoTouchService/include/ServiceHost.h
+++ b/EGoTouchService/include/ServiceHost.h
@@ -100,6 +100,9 @@ private:
 
     void HandleIpcEnterDebugMode(Ipc::IpcResponse& resp);
     void HandleIpcExitDebugMode(Ipc::IpcResponse& resp);
+    void HandleIpcGetConfigSnapshot(Ipc::IpcResponse& resp);
+    void HandleIpcApplyConfigPatch(const Ipc::IpcRequest& req, Ipc::IpcResponse& resp);
+    void HandleIpcPersistConfig(Ipc::IpcResponse& resp);
     void HandleIpcReloadConfig(Ipc::IpcResponse& resp);
     void HandleIpcSaveConfig(Ipc::IpcResponse& resp);
     void HandleIpcGetLogs(Ipc::IpcResponse& resp);

--- a/EGoTouchService/source/ServiceHost.cpp
+++ b/EGoTouchService/source/ServiceHost.cpp
@@ -7,27 +7,29 @@
 #include "IpcPipeServer.h"
 #include "SharedFrameBuffer.h"
 #include "ConfigSync.h"
+#include "SolverTypes.h"
 
 #include "GuiLogSink.h"
 #include "Logger.h"
 #include "IpcProtocol.h"
 
-#include <fstream>
-#include <string>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
 #include <algorithm>
-#include <array>
 #include <cctype>
-#include <cmath>
 #include <cstring>
-#include <ctime>
+#include <fstream>
 #include <filesystem>
 #include <iomanip>
+#include <mutex>
 #include <optional>
 #include <sstream>
+#include <string>
 #include <string_view>
-
-// Engine Pipeline Processors
-#include "TouchSolver/TouchPipeline.h"
+#include <ctime>
 
 namespace Service {
 
@@ -79,6 +81,35 @@ enum class DebugDerivedSourceIndex : int16_t {
 
 constexpr uint8_t ToFieldBit(ServiceConfigField field) {
     return static_cast<uint8_t>(1u << static_cast<uint8_t>(field));
+}
+
+constexpr uint8_t ToPersistedFieldBits() {
+    return Ipc::ToBits(Ipc::ServiceConfigFieldWire::Mode) |
+           Ipc::ToBits(Ipc::ServiceConfigFieldWire::AutoMode) |
+           Ipc::ToBits(Ipc::ServiceConfigFieldWire::StylusVhfEnabled);
+}
+
+constexpr uint8_t ToWireServiceMode(ServiceMode mode) {
+    switch (mode) {
+    case ServiceMode::Full:
+        return static_cast<uint8_t>(Ipc::ServiceModeWire::Full);
+    case ServiceMode::TouchOnly:
+        return static_cast<uint8_t>(Ipc::ServiceModeWire::TouchOnly);
+    }
+    return static_cast<uint8_t>(Ipc::ServiceModeWire::Full);
+}
+
+bool TryParseWireServiceMode(uint8_t wireValue, ServiceMode& out) {
+    switch (static_cast<Ipc::ServiceModeWire>(wireValue)) {
+    case Ipc::ServiceModeWire::Full:
+        out = ServiceMode::Full;
+        return true;
+    case Ipc::ServiceModeWire::TouchOnly:
+        out = ServiceMode::TouchOnly;
+        return true;
+    default:
+        return false;
+    }
 }
 
 uint64_t EncodeU32(uint32_t value) {
@@ -140,6 +171,25 @@ bool ParseIniKeyValue(std::string_view line, std::string& key, std::string& valu
     key = TrimCopy(line.substr(0, eq));
     value = TrimCopy(line.substr(eq + 1));
     return !key.empty();
+}
+
+bool HasIniSection(const std::string& configPath, std::string_view sectionName) {
+    std::ifstream cfg(configPath);
+    if (!cfg.is_open()) {
+        return false;
+    }
+
+    std::string line;
+    while (std::getline(cfg, line)) {
+        const std::string trimmed = TrimCopy(line);
+        if (trimmed.empty() || trimmed[0] == ';' || trimmed[0] == '#') continue;
+        if (trimmed.front() != '[' || trimmed.back() != ']') continue;
+        const std::string current = TrimCopy(std::string_view(trimmed).substr(1, trimmed.size() - 2));
+        if (current == sectionName) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool IsLegacyTouchSection(const std::string& section) {
@@ -226,8 +276,7 @@ bool WriteCanonicalConfig(const std::string& configPath,
                           ServiceMode mode,
                           bool autoMode,
                           bool stylusVhfEnabled,
-                          const Solvers::TouchPipeline& touchPipe,
-                          const Solvers::StylusPipeline& stylusPipe) {
+                          const DeviceRuntime& runtime) {
     std::ofstream out(configPath, std::ios::trunc);
     if (!out.is_open()) return false;
 
@@ -237,13 +286,45 @@ bool WriteCanonicalConfig(const std::string& configPath,
     out << "stylus_vhf_enabled=" << (stylusVhfEnabled ? "1" : "0") << "\n\n";
 
     out << "[TouchPipeline]\n";
-    touchPipe.SaveConfig(out);
+    runtime.SavePipelineConfig(out);
     out << "\n";
 
     out << "[StylusPipeline]\n";
-    stylusPipe.SaveConfig(out);
+    runtime.SaveStylusPipelineConfig(out);
     out << "\n";
     return true;
+}
+
+RuntimePolicyEvent TranslateSystemStateEvent(const Host::SystemStateEvent& event) {
+    RuntimePolicyEvent translated{};
+    translated.timestamp = event.timestamp;
+    translated.rawIndex = event.raw_index;
+
+    switch (event.type) {
+    case Host::SystemStateEventType::DisplayOn:
+        translated.type = RuntimePolicyEvent::Type::DisplayOn;
+        break;
+    case Host::SystemStateEventType::DisplayOff:
+        translated.type = RuntimePolicyEvent::Type::DisplayOff;
+        break;
+    case Host::SystemStateEventType::LidOn:
+        translated.type = RuntimePolicyEvent::Type::LidOn;
+        break;
+    case Host::SystemStateEventType::LidOff:
+        translated.type = RuntimePolicyEvent::Type::LidOff;
+        break;
+    case Host::SystemStateEventType::Shutdown:
+        translated.type = RuntimePolicyEvent::Type::Shutdown;
+        break;
+    case Host::SystemStateEventType::ResumeAutomatic:
+        translated.type = RuntimePolicyEvent::Type::ResumeAutomatic;
+        break;
+    default:
+        translated.type = RuntimePolicyEvent::Type::Unknown;
+        break;
+    }
+
+    return translated;
 }
 
 } // namespace
@@ -294,8 +375,7 @@ ServiceHost::ServiceConfigState ServiceHost::ParseServiceConfig(const std::strin
 void ServiceHost::ApplyServiceConfigToRuntime(const ServiceConfigState& config) {
     if (!m_deviceRuntime) return;
 
-    m_deviceRuntime->SetAutoMode(config.autoMode);
-    m_deviceRuntime->SetStylusVhfEnabled(config.stylusVhfEnabled);
+    m_deviceRuntime->ApplyServicePolicy(config.autoMode, config.stylusVhfEnabled);
 }
 
 ServiceHost::ReloadServiceConfigResult ServiceHost::HandleReloadServiceConfig(
@@ -318,10 +398,6 @@ ServiceHost::ReloadServiceConfigResult ServiceHost::HandleReloadServiceConfig(
 
     if (autoModeChanged) {
         result.changedFields |= ToFieldBit(ServiceConfigField::AutoMode);
-        if (m_deviceRuntime) {
-            m_deviceRuntime->SetAutoMode(reloadedConfig.autoMode);
-            result.appliedFields |= ToFieldBit(ServiceConfigField::AutoMode);
-        }
         LOG_INFO("Service", __func__, "IPC",
                  "[Service].auto_mode reloaded to {} (immediate apply).",
                  reloadedConfig.autoMode ? 1 : 0);
@@ -329,13 +405,16 @@ ServiceHost::ReloadServiceConfigResult ServiceHost::HandleReloadServiceConfig(
 
     if (stylusVhfChanged) {
         result.changedFields |= ToFieldBit(ServiceConfigField::StylusVhfEnabled);
-        if (m_deviceRuntime) {
-            m_deviceRuntime->SetStylusVhfEnabled(reloadedConfig.stylusVhfEnabled);
-            result.appliedFields |= ToFieldBit(ServiceConfigField::StylusVhfEnabled);
-        }
         LOG_INFO("Service", __func__, "IPC",
                  "[Service].stylus_vhf_enabled reloaded to {} (immediate apply).",
                  reloadedConfig.stylusVhfEnabled ? 1 : 0);
+    }
+
+    if (m_deviceRuntime && (autoModeChanged || stylusVhfChanged)) {
+        m_deviceRuntime->ApplyServicePolicy(reloadedConfig.autoMode, reloadedConfig.stylusVhfEnabled);
+        result.appliedFields |= static_cast<uint8_t>(
+            (autoModeChanged ? ToFieldBit(ServiceConfigField::AutoMode) : 0u) |
+            (stylusVhfChanged ? ToFieldBit(ServiceConfigField::StylusVhfEnabled) : 0u));
     }
 
     m_configState = reloadedConfig;
@@ -363,7 +442,7 @@ void ServiceHost::StartSystemStateMonitor() {
     const bool monitorOk = m_impl->m_sysMonitor->Start(
         [this](const Host::SystemStateEvent& ev) {
             LOG_INFO("Service", __func__, "Event", "System event: type={}", Host::ToString(ev.type));
-            m_deviceRuntime->IngestSystemEvent(ev);
+            m_deviceRuntime->IngestPolicyEvent(TranslateSystemStateEvent(ev));
         });
 
     if (!monitorOk) {
@@ -430,7 +509,7 @@ void ServiceHost::StartPenSubsystem() {
     m_impl->m_penEventBridge->SetEventCallback(
         [this](const Himax::Pen::PenEvent& ev) {
             if (m_deviceRuntime) {
-                m_deviceRuntime->OnPenEvent(ev);
+                m_deviceRuntime->IngestPenEvent(ev);
             }
         });
     m_impl->m_penEventBridge->Start();
@@ -443,7 +522,7 @@ void ServiceHost::StartPenSubsystem() {
     m_impl->m_penPressureReader->SetPressureCallback(
         [this](uint16_t press) {
             if (m_deviceRuntime) {
-                m_deviceRuntime->SetBtMcuPressure(press);
+                m_deviceRuntime->IngestBtMcuPressure(press);
             }
         });
     m_impl->m_penPressureReader->Start();
@@ -542,10 +621,11 @@ void ServiceHost::Stop() {
 }
 
 // ── Shared config loader ────────────────────────────────────────────
-static LoadPipelineConfigResult LoadPipelineConfig(
+template <typename TouchLoader, typename StylusLoader>
+LoadPipelineConfigResult LoadPipelineConfig(
     const std::string& configPath,
-    Solvers::TouchPipeline& touchPipe,
-    Solvers::StylusPipeline* stylusPipe = nullptr)
+    TouchLoader&& loadTouch,
+    StylusLoader&& loadStylus)
 {
     LoadPipelineConfigResult result;
     std::ifstream in(configPath);
@@ -566,19 +646,19 @@ static LoadPipelineConfigResult LoadPipelineConfig(
         if (!ParseIniKeyValue(trimmed, key, val)) continue;
 
         if (section == "TouchPipeline") {
-            touchPipe.LoadConfig(key, val);
+            loadTouch(key, val);
             result.touchLoaded = true;
             continue;
         }
-        if (stylusPipe && section == "StylusPipeline") {
-            stylusPipe->LoadConfig(key, val);
+        if (section == "StylusPipeline") {
+            loadStylus(key, val);
             result.stylusLoaded = true;
             continue;
         }
         if (IsLegacyTouchSection(section)) {
             const auto mappedKey = MapLegacyTouchKey(section, key);
             if (!mappedKey.has_value()) continue;
-            touchPipe.LoadConfig(*mappedKey, val);
+            loadTouch(*mappedKey, val);
             result.touchLoaded = true;
             result.migrated = true;
         }
@@ -865,12 +945,16 @@ void ServiceHost::BuildDebugSchema() {
 void ServiceHost::BuildDefaultPipeline(const std::string& configPath) {
     // TouchPipeline is self-contained: no processor registration needed.
     // Just load config.
-    auto& tp = m_deviceRuntime->GetPipeline();
-    auto& sp = m_deviceRuntime->GetStylusPipeline();
+    auto loadTouch = [this](const std::string& key, const std::string& value) {
+        m_deviceRuntime->LoadPipelineConfig(key, value);
+    };
+    auto loadStylus = [this](const std::string& key, const std::string& value) {
+        m_deviceRuntime->LoadStylusPipelineConfig(key, value);
+    };
     LOG_INFO("Service", __func__, "Boot", "TouchPipeline initialized (linear orchestrator).");
 
     // Load saved config
-    const auto loadResult = LoadPipelineConfig(configPath, tp, &sp);
+    const auto loadResult = LoadPipelineConfig(configPath, loadTouch, loadStylus);
     if (!loadResult.fileOpened) {
         LOG_WARN("Service", __func__, "Boot", "Config file not found: {}", configPath);
         return;
@@ -879,7 +963,7 @@ void ServiceHost::BuildDefaultPipeline(const std::string& configPath) {
     if (loadResult.migrated) {
         std::string backupPath;
         if (BackupConfigFile(configPath, backupPath)) {
-            if (WriteCanonicalConfig(configPath, m_configState.mode, m_configState.autoMode, m_configState.stylusVhfEnabled, tp, sp)) {
+            if (WriteCanonicalConfig(configPath, m_configState.mode, m_configState.autoMode, m_configState.stylusVhfEnabled, *m_deviceRuntime)) {
                 LOG_INFO("Service", __func__, "Boot",
                          "Migrated legacy pipeline config from {} and rewrote canonical sections. Backup: {}",
                          configPath, backupPath);
@@ -917,15 +1001,19 @@ void ServiceHost::HandleIpcEnterDebugMode(Ipc::IpcResponse& resp) {
                     m_impl->m_latestDebugFrame = f;
                     m_impl->m_hasLatestDebugFrame = true;
                 }
-                m_impl->m_frameWriter.Write(f);
+                Ipc::SharedFrameData sharedFrame{};
+                Ipc::PopulateSharedFrameDataFromSolverFrame(sharedFrame, f);
+                m_impl->m_frameWriter.Write(sharedFrame);
             });
         m_impl->m_debugMode = true;
-        resp.success = true;
+        Ipc::MarkSuccess(resp);
         LOG_INFO("Service", __func__, "IPC", "Entered debug mode.");
     } else {
+        Ipc::MarkFailure(resp, Ipc::IpcStatusCode::InvalidState);
         LOG_ERROR("Service", __func__, "IPC", "EnterDebugMode rejected: shared memory not available.");
     }
 #else
+    Ipc::MarkFailure(resp, Ipc::IpcStatusCode::UnsupportedCommand);
     LOG_WARN("Service", __func__, "IPC", "EnterDebugMode not available in release build.");
 #endif
 }
@@ -941,30 +1029,112 @@ void ServiceHost::HandleIpcExitDebugMode(Ipc::IpcResponse& resp) {
     m_impl->m_debugMode = false;
 #endif
 
-    resp.success = true;
+    Ipc::MarkSuccess(resp);
     LOG_INFO("Service", __func__, "IPC", "Exited debug mode.");
+}
+
+void ServiceHost::HandleIpcGetConfigSnapshot(Ipc::IpcResponse& resp) {
+    Ipc::ConfigSnapshotWire snapshot{};
+    snapshot.definedFields = ToPersistedFieldBits();
+    snapshot.desiredMode = ToWireServiceMode(m_configState.mode);
+    snapshot.activeMode = ToWireServiceMode(m_runtimeMode);
+    snapshot.autoMode = m_configState.autoMode ? 1 : 0;
+    snapshot.stylusVhfEnabled = m_configState.stylusVhfEnabled ? 1 : 0;
+
+    std::memcpy(resp.data, &snapshot, sizeof(snapshot));
+    resp.dataLen = static_cast<uint16_t>(sizeof(snapshot));
+    Ipc::MarkSuccess(resp);
+}
+
+void ServiceHost::HandleIpcApplyConfigPatch(const Ipc::IpcRequest& req, Ipc::IpcResponse& resp) {
+    if (!m_deviceRuntime) {
+        Ipc::MarkFailure(resp, Ipc::IpcStatusCode::InvalidState);
+        return;
+    }
+    if (req.paramLen < sizeof(Ipc::ApplyConfigPatchRequestWire)) {
+        Ipc::MarkFailure(resp, Ipc::IpcStatusCode::InvalidRequest);
+        return;
+    }
+
+    Ipc::ApplyConfigPatchRequestWire patch{};
+    std::memcpy(&patch, req.param, sizeof(patch));
+    if (patch.wireVersion != Ipc::kIpcProtocolVersion) {
+        Ipc::MarkFailure(resp, Ipc::IpcStatusCode::InvalidRequest);
+        return;
+    }
+
+    ServiceConfigState desired = m_configState;
+    if (Ipc::HasField(patch.fieldMask, Ipc::ServiceConfigFieldWire::Mode)) {
+        if (!TryParseWireServiceMode(patch.desiredMode, desired.mode)) {
+            Ipc::MarkFailure(resp, Ipc::IpcStatusCode::InvalidRequest);
+            return;
+        }
+    }
+    if (Ipc::HasField(patch.fieldMask, Ipc::ServiceConfigFieldWire::AutoMode)) {
+        desired.autoMode = patch.autoMode != 0;
+    }
+    if (Ipc::HasField(patch.fieldMask, Ipc::ServiceConfigFieldWire::StylusVhfEnabled)) {
+        desired.stylusVhfEnabled = patch.stylusVhfEnabled != 0;
+    }
+
+    const auto reloadState = HandleReloadServiceConfig(desired);
+
+    Ipc::ConfigMutationResultWire result{};
+    result.changedFields = reloadState.changedFields;
+    result.appliedFields = reloadState.appliedFields;
+    result.restartRequiredFields = reloadState.restartRequiredFields;
+
+    std::memcpy(resp.data, &result, sizeof(result));
+    resp.dataLen = static_cast<uint16_t>(sizeof(result));
+    Ipc::MarkSuccess(resp);
+}
+
+void ServiceHost::HandleIpcPersistConfig(Ipc::IpcResponse& resp) {
+    if (!m_deviceRuntime) {
+        Ipc::MarkFailure(resp, Ipc::IpcStatusCode::InvalidState);
+        return;
+    }
+
+    if (!WriteCanonicalConfig(kConfigPath, m_configState.mode, m_configState.autoMode, m_configState.stylusVhfEnabled, *m_deviceRuntime)) {
+        Ipc::MarkFailure(resp, Ipc::IpcStatusCode::InternalError);
+        return;
+    }
+
+    Ipc::PersistConfigResponseWire result{};
+    result.persistedFields = ToPersistedFieldBits();
+    std::memcpy(resp.data, &result, sizeof(result));
+    resp.dataLen = static_cast<uint16_t>(sizeof(result));
+    Ipc::MarkSuccess(resp);
+    LOG_INFO("Service", __func__, "IPC", "Canonical config persisted to {}.", kConfigPath);
 }
 
 void ServiceHost::HandleIpcReloadConfig(Ipc::IpcResponse& resp) {
     if (!m_deviceRuntime) {
+        Ipc::MarkFailure(resp, Ipc::IpcStatusCode::InvalidState);
         return;
     }
 
-    auto& tp = m_deviceRuntime->GetPipeline();
-    auto& sp = m_deviceRuntime->GetStylusPipeline();
-    const auto loadResult = LoadPipelineConfig(kConfigPath, tp, &sp);
+    auto loadTouch = [this](const std::string& key, const std::string& value) {
+        m_deviceRuntime->LoadPipelineConfig(key, value);
+    };
+    auto loadStylus = [this](const std::string& key, const std::string& value) {
+        m_deviceRuntime->LoadStylusPipelineConfig(key, value);
+    };
+    const auto loadResult = LoadPipelineConfig(kConfigPath, loadTouch, loadStylus);
     if (!loadResult.fileOpened) {
         LOG_WARN("Service", __func__, "IPC", "ReloadConfig failed: config file not found: {}", kConfigPath);
+        Ipc::MarkFailure(resp, Ipc::IpcStatusCode::NotFound);
         return;
     }
 
     const auto reloadedConfig = ParseServiceConfig(kConfigPath);
     const auto reloadState = HandleReloadServiceConfig(reloadedConfig);
+    const bool missingCanonicalServiceSection = !HasIniSection(kConfigPath, "Service");
 
-    if (loadResult.migrated) {
+    if (loadResult.migrated || missingCanonicalServiceSection) {
         std::string backupPath;
         if (BackupConfigFile(kConfigPath, backupPath)) {
-            if (WriteCanonicalConfig(kConfigPath, m_configState.mode, m_configState.autoMode, m_configState.stylusVhfEnabled, tp, sp)) {
+            if (WriteCanonicalConfig(kConfigPath, m_configState.mode, m_configState.autoMode, m_configState.stylusVhfEnabled, *m_deviceRuntime)) {
                 LOG_INFO("Service", __func__, "IPC",
                          "Reloaded legacy config from {} and rewrote canonical sections. Backup: {}",
                          kConfigPath, backupPath);
@@ -996,24 +1166,17 @@ void ServiceHost::HandleIpcReloadConfig(Ipc::IpcResponse& resp) {
                  static_cast<unsigned int>(reloadState.restartRequiredFields));
     }
 
-    resp.success = true;
-    resp.dataLen = 3;
-    resp.data[0] = reloadState.changedFields;
-    resp.data[1] = reloadState.appliedFields;
-    resp.data[2] = reloadState.restartRequiredFields;
+    Ipc::ReloadConfigSummaryWire summary{};
+    summary.changedFields = reloadState.changedFields;
+    summary.appliedFields = reloadState.appliedFields;
+    summary.restartRequiredFields = reloadState.restartRequiredFields;
+    std::memcpy(resp.data, &summary, sizeof(summary));
+    resp.dataLen = static_cast<uint16_t>(sizeof(summary));
+    Ipc::MarkSuccess(resp);
 }
 
 void ServiceHost::HandleIpcSaveConfig(Ipc::IpcResponse& resp) {
-    if (!m_deviceRuntime) {
-        return;
-    }
-
-    auto& tp = m_deviceRuntime->GetPipeline();
-    auto& sp = m_deviceRuntime->GetStylusPipeline();
-    if (WriteCanonicalConfig(kConfigPath, m_configState.mode, m_configState.autoMode, m_configState.stylusVhfEnabled, tp, sp)) {
-        resp.success = true;
-        LOG_INFO("Service", __func__, "IPC", "Config saved to {}.", kConfigPath);
-    }
+    HandleIpcPersistConfig(resp);
 }
 
 void ServiceHost::HandleIpcGetLogs(Ipc::IpcResponse& resp) {
@@ -1164,42 +1327,57 @@ Ipc::IpcResponse ServiceHost::HandleIpcCommand(const Ipc::IpcRequest& req) {
 
     case Ipc::IpcCommand::AfeCommand:
         if (req.paramLen >= 2 && m_deviceRuntime) {
-            command cmd{
-                .type = static_cast<AFE_Command>(req.param[0]),
-                .param = req.param[1],
-            };
-            m_deviceRuntime->SubmitCommand(cmd, CommandSource::External, "IPC AFE");
-            resp.success = true;
+            resp.success = m_deviceRuntime->SubmitExternalAfeCommand(
+                static_cast<AFE_Command>(req.param[0]), req.param[1]);
         }
         break;
 
     case Ipc::IpcCommand::StartRuntime:
         if (m_deviceRuntime) {
-            if (m_deviceRuntime->IsRunning()) {
+            switch (m_deviceRuntime->RequestStart()) {
+            case DeviceRuntime::StartRequestResult::Started:
+                resp.success = true;
+                LOG_INFO("Service", __func__, "IPC", "StartRuntime accepted: runtime started.");
+                break;
+            case DeviceRuntime::StartRequestResult::AlreadyRunning:
                 resp.success = true;
                 LOG_INFO("Service", __func__, "IPC", "StartRuntime accepted: runtime already running (idempotent no-op).");
-            } else {
-                resp.success = m_deviceRuntime->Start();
-                if (resp.success) {
-                    LOG_INFO("Service", __func__, "IPC", "StartRuntime accepted: runtime started.");
-                } else {
-                    LOG_WARN("Service", __func__, "IPC", "StartRuntime failed: runtime did not start.");
-                }
+                break;
+            case DeviceRuntime::StartRequestResult::Failed:
+            default:
+                resp.success = false;
+                LOG_WARN("Service", __func__, "IPC", "StartRuntime failed: runtime did not start.");
+                break;
             }
         }
         break;
 
     case Ipc::IpcCommand::StopRuntime:
         if (m_deviceRuntime) {
-            if (!m_deviceRuntime->IsRunning()) {
-                resp.success = true;
-                LOG_INFO("Service", __func__, "IPC", "StopRuntime accepted: runtime already stopped (idempotent no-op).");
-            } else {
-                m_deviceRuntime->Stop();
+            switch (m_deviceRuntime->RequestStop()) {
+            case DeviceRuntime::StopRequestResult::Stopped:
                 resp.success = true;
                 LOG_INFO("Service", __func__, "IPC", "StopRuntime accepted: runtime stopped.");
+                break;
+            case DeviceRuntime::StopRequestResult::AlreadyStopped:
+            default:
+                resp.success = true;
+                LOG_INFO("Service", __func__, "IPC", "StopRuntime accepted: runtime already stopped (idempotent no-op).");
+                break;
             }
         }
+        break;
+
+    case Ipc::IpcCommand::GetConfigSnapshot:
+        HandleIpcGetConfigSnapshot(resp);
+        break;
+
+    case Ipc::IpcCommand::ApplyConfigPatch:
+        HandleIpcApplyConfigPatch(req, resp);
+        break;
+
+    case Ipc::IpcCommand::PersistConfig:
+        HandleIpcPersistConfig(resp);
         break;
 
     case Ipc::IpcCommand::ReloadConfig:
@@ -1212,14 +1390,14 @@ Ipc::IpcResponse ServiceHost::HandleIpcCommand(const Ipc::IpcRequest& req) {
 
     case Ipc::IpcCommand::SetVhfEnabled:
         if (m_deviceRuntime && req.paramLen >= 1) {
-            m_deviceRuntime->GetVhfReporter().SetEnabled(req.param[0] != 0);
+            m_deviceRuntime->SetVhfEnabled(req.param[0] != 0);
             resp.success = true;
         }
         break;
 
     case Ipc::IpcCommand::SetVhfTranspose:
         if (m_deviceRuntime && req.paramLen >= 1) {
-            m_deviceRuntime->GetVhfReporter().SetTransposeEnabled(req.param[0] != 0);
+            m_deviceRuntime->SetVhfTransposeEnabled(req.param[0] != 0);
             resp.success = true;
         }
         break;

--- a/Tools/EGoTouchApp/include/ServiceProxy.h
+++ b/Tools/EGoTouchApp/include/ServiceProxy.h
@@ -92,7 +92,6 @@ public:
     // Config sync
     void SaveConfig();
     void LoadConfig();
-    void NotifyConfigDirty();
 
     // VHF control (forwarded to Service via IPC)
     bool SetVhfEnabled(bool enabled);
@@ -109,11 +108,13 @@ public:
     bool IsDvrExporting() const { return m_dvrExporting.load(); }
 
     // Global Service config (UI mirrors)
-    bool IsSrvModeFull() const { return m_srvModeFull; }
+    // NOTE: IsSrvModeFull() returns desired mode (config target), not runtime active mode.
+    bool IsSrvModeFull() const { return m_srvDesiredModeFull.load(std::memory_order_relaxed); }
+    bool IsSrvActiveModeFull() const { return m_srvActiveModeFull.load(std::memory_order_relaxed); }
     void SetSrvModeFull(bool full);
-    bool IsSrvStylusVhfEnabled() const { return m_srvStylusVhfEnabled; }
+    bool IsSrvStylusVhfEnabled() const { return m_srvStylusVhfEnabled.load(std::memory_order_relaxed); }
     void SetSrvStylusVhfEnabled(bool enabled);
-    bool IsSrvAutoMode() const { return m_srvAutoMode; }
+    bool IsSrvAutoMode() const { return m_srvAutoMode.load(std::memory_order_relaxed); }
     void SetSrvAutoMode(bool enabled);
 
     // PenBridge status (polled from Service)
@@ -145,7 +146,6 @@ private:
 
     Ipc::IpcPipeClient    m_client;
     Ipc::SharedFrameReader m_frameReader;
-    Ipc::ConfigDirtyFlag  m_configDirty;
     Solvers::TouchPipeline m_pipeline;
     Solvers::StylusPipeline m_stylusPipeline;
 
@@ -208,9 +208,10 @@ private:
     std::atomic<int> m_slaveFps{0};
 
     // Global Service config mirrors
-    bool m_srvModeFull = true;
-    bool m_srvAutoMode = true;
-    bool m_srvStylusVhfEnabled = true;
+    std::atomic<bool> m_srvDesiredModeFull{true};
+    std::atomic<bool> m_srvActiveModeFull{true};
+    std::atomic<bool> m_srvAutoMode{true};
+    std::atomic<bool> m_srvStylusVhfEnabled{true};
 };
 
 } // namespace App

--- a/Tools/EGoTouchApp/source/ServiceProxy.Config.cpp
+++ b/Tools/EGoTouchApp/source/ServiceProxy.Config.cpp
@@ -15,6 +15,72 @@ namespace App {
 void ServiceProxy::SaveConfig() {
     if (!IsLiveControlAllowed()) return;
 
+    const bool serviceConnected = m_client.IsConnected();
+    const bool requestedSrvModeFull = m_srvDesiredModeFull.load(std::memory_order_relaxed);
+    const bool requestedSrvAutoMode = m_srvAutoMode.load(std::memory_order_relaxed);
+    const bool requestedSrvStylusVhfEnabled = m_srvStylusVhfEnabled.load(std::memory_order_relaxed);
+
+    std::string serviceSection = BuildServiceConfigSection(
+        requestedSrvModeFull,
+        requestedSrvAutoMode,
+        requestedSrvStylusVhfEnabled);
+
+    Ipc::ConfigMutationResultWire patchSummary{};
+    bool havePatchSummary = false;
+    bool skipLocalServiceSection = false;
+
+    // Thin-client primary path: Service is authoritative for [Service] config.
+    if (serviceConnected) {
+        Ipc::ApplyConfigPatchRequestWire patch{};
+        patch.fieldMask = Ipc::ToBits(Ipc::ServiceConfigFieldWire::Mode) |
+                          Ipc::ToBits(Ipc::ServiceConfigFieldWire::AutoMode) |
+                          Ipc::ToBits(Ipc::ServiceConfigFieldWire::StylusVhfEnabled);
+        patch.desiredMode = static_cast<uint8_t>(requestedSrvModeFull ? Ipc::ServiceModeWire::Full
+                                                                      : Ipc::ServiceModeWire::TouchOnly);
+        patch.autoMode = requestedSrvAutoMode ? 1 : 0;
+        patch.stylusVhfEnabled = requestedSrvStylusVhfEnabled ? 1 : 0;
+
+        const auto applyResp = m_client.ApplyConfigPatch(patch);
+        if (!applyResp.success) {
+            LOG_WARN("App", __func__, "IPC", "ApplyConfigPatch failed with status={}", static_cast<unsigned int>(applyResp.status));
+            return;
+        }
+        if (applyResp.dataLen >= sizeof(patchSummary)) {
+            std::memcpy(&patchSummary, applyResp.data, sizeof(patchSummary));
+            havePatchSummary = true;
+        }
+
+        const auto persistResp = m_client.PersistConfig();
+        if (!persistResp.success) {
+            LOG_WARN("App", __func__, "IPC", "ApplyConfigPatch succeeded but PersistConfig failed with status={}", static_cast<unsigned int>(persistResp.status));
+            // Service owns [Service] config in connected mode. If persist fails,
+            // do not write local [Service] section from client-side state.
+            skipLocalServiceSection = true;
+        }
+
+        // Refresh mirrors from canonical snapshot (desired vs active semantics).
+        const auto snapshotResp = m_client.GetConfigSnapshot();
+        if (snapshotResp.success && snapshotResp.dataLen >= sizeof(Ipc::ConfigSnapshotWire)) {
+            Ipc::ConfigSnapshotWire snapshot{};
+            std::memcpy(&snapshot, snapshotResp.data, sizeof(snapshot));
+            const bool desiredFull = snapshot.desiredMode == static_cast<uint8_t>(Ipc::ServiceModeWire::Full);
+            const bool activeFull = snapshot.activeMode == static_cast<uint8_t>(Ipc::ServiceModeWire::Full);
+            const bool autoMode = snapshot.autoMode != 0;
+            const bool stylusVhfEnabled = snapshot.stylusVhfEnabled != 0;
+
+            m_srvDesiredModeFull.store(desiredFull, std::memory_order_relaxed);
+            m_srvActiveModeFull.store(activeFull, std::memory_order_relaxed);
+            m_srvAutoMode.store(autoMode, std::memory_order_relaxed);
+            m_srvStylusVhfEnabled.store(stylusVhfEnabled, std::memory_order_relaxed);
+
+            serviceSection = BuildServiceConfigSection(desiredFull, autoMode, stylusVhfEnabled);
+        } else {
+            LOG_WARN("App", __func__, "IPC", "GetConfigSnapshot failed after patch/persist; skip local [Service] overwrite in connected mode.");
+            skipLocalServiceSection = true;
+        }
+    }
+
+    // Compatibility path: persist local pipeline sections for existing load/reload behavior.
     std::ifstream in(kConfigPath, std::ios::binary);
     std::string existingText;
     if (in.is_open()) {
@@ -29,7 +95,7 @@ void ServiceProxy::SaveConfig() {
 
     const std::string mergedConfig = MergeServiceProxyConfigSections(
         existingText,
-        BuildServiceConfigSection(m_srvModeFull, m_srvAutoMode, m_srvStylusVhfEnabled),
+        skipLocalServiceSection ? std::string_view{} : std::string_view(serviceSection),
         BuildTouchPipelineConfigSection(m_pipeline, persistedModuleState),
         BuildStylusPipelineConfigSection(m_stylusPipeline));
 
@@ -52,36 +118,65 @@ void ServiceProxy::SaveConfig() {
         return;
     }
 
-    // Notify Service to reload from config.ini
-    m_configDirty.SetDirty();
-    const auto resp = m_client.ReloadConfig();
-    if (!resp.success) {
-        LOG_WARN("App", __func__, "IPC", "Config saved but ReloadConfig IPC failed.");
+    if (!serviceConnected) {
+        LOG_INFO("App", __func__, "Config", "Config saved locally while service is disconnected.");
         return;
     }
 
-    if (resp.dataLen >= sizeof(Ipc::ReloadConfigSummaryWire)) {
-        Ipc::ReloadConfigSummaryWire summary{};
-        std::memcpy(&summary, resp.data, sizeof(summary));
-        if (summary.restartRequiredFields != 0u) {
-            LOG_WARN("App", __func__, "IPC",
-                     "Config saved/reloaded. Restart required for some [Service] fields: changed=0x{:02X} applied_now=0x{:02X} restart_required=0x{:02X}.",
-                     static_cast<unsigned int>(summary.changedFields),
-                     static_cast<unsigned int>(summary.appliedFields),
-                     static_cast<unsigned int>(summary.restartRequiredFields));
-        } else {
-            LOG_INFO("App", __func__, "IPC",
-                     "Config saved/reloaded: changed=0x{:02X} applied_now=0x{:02X} restart_required=0x{:02X}.",
-                     static_cast<unsigned int>(summary.changedFields),
-                     static_cast<unsigned int>(summary.appliedFields),
-                     static_cast<unsigned int>(summary.restartRequiredFields));
-        }
+    // Legacy compatibility: pipeline/stylus settings still apply via ReloadConfig.
+    const auto reloadResp = m_client.ReloadConfig();
+    if (!reloadResp.success) {
+        LOG_WARN("App", __func__, "IPC", "Config patched/persisted and file updated, but ReloadConfig IPC failed with status={}", static_cast<unsigned int>(reloadResp.status));
+    }
+
+    Ipc::ReloadConfigSummaryWire reloadSummary{};
+    if (reloadResp.success && reloadResp.dataLen >= sizeof(reloadSummary)) {
+        std::memcpy(&reloadSummary, reloadResp.data, sizeof(reloadSummary));
+    }
+
+    Ipc::ConfigMutationResultWire summary{};
+    if (havePatchSummary) {
+        summary = patchSummary;
     } else {
-        LOG_INFO("App", __func__, "IPC", "Config saved and Service notified to reload.");
+        summary.changedFields = reloadSummary.changedFields;
+        summary.appliedFields = reloadSummary.appliedFields;
+        summary.restartRequiredFields = reloadSummary.restartRequiredFields;
+    }
+
+    if (summary.restartRequiredFields != 0u) {
+        LOG_WARN("App", __func__, "IPC",
+                 "Config patched/persisted: changed=0x{:02X} applied_now=0x{:02X} restart_required=0x{:02X}.",
+                 static_cast<unsigned int>(summary.changedFields),
+                 static_cast<unsigned int>(summary.appliedFields),
+                 static_cast<unsigned int>(summary.restartRequiredFields));
+    } else {
+        LOG_INFO("App", __func__, "IPC",
+                 "Config patched/persisted: changed=0x{:02X} applied_now=0x{:02X} restart_required=0x{:02X}.",
+                 static_cast<unsigned int>(summary.changedFields),
+                 static_cast<unsigned int>(summary.appliedFields),
+                 static_cast<unsigned int>(summary.restartRequiredFields));
     }
 }
 
 void ServiceProxy::LoadConfig() {
+    bool loadedServiceFromSnapshot = false;
+    if (m_client.IsConnected()) {
+        const auto resp = m_client.GetConfigSnapshot();
+        if (resp.success && resp.dataLen >= sizeof(Ipc::ConfigSnapshotWire)) {
+            Ipc::ConfigSnapshotWire snapshot{};
+            std::memcpy(&snapshot, resp.data, sizeof(snapshot));
+            m_srvDesiredModeFull.store(
+                snapshot.desiredMode == static_cast<uint8_t>(Ipc::ServiceModeWire::Full),
+                std::memory_order_relaxed);
+            m_srvActiveModeFull.store(
+                snapshot.activeMode == static_cast<uint8_t>(Ipc::ServiceModeWire::Full),
+                std::memory_order_relaxed);
+            m_srvAutoMode.store(snapshot.autoMode != 0, std::memory_order_relaxed);
+            m_srvStylusVhfEnabled.store(snapshot.stylusVhfEnabled != 0, std::memory_order_relaxed);
+            loadedServiceFromSnapshot = true;
+        }
+    }
+
     std::ifstream in(kConfigPath);
     if (!in.is_open()) return;
     std::string line, section;
@@ -98,9 +193,18 @@ void ServiceProxy::LoadConfig() {
         if (!ParseIniKeyValue(trimmed, key, value)) continue;
 
         if (section == "Service") {
-            if (key == "mode") m_srvModeFull = (value == "full");
-            else if (key == "auto_mode") m_srvAutoMode = (value == "1" || value == "true");
-            else if (key == "stylus_vhf_enabled") m_srvStylusVhfEnabled = (value == "1" || value == "true");
+            if (!loadedServiceFromSnapshot) {
+                if (key == "mode") {
+                    const bool desiredFull = (value == "full");
+                    m_srvDesiredModeFull.store(desiredFull, std::memory_order_relaxed);
+                    // Offline fallback has no runtime distinction; mirror desired->active.
+                    m_srvActiveModeFull.store(desiredFull, std::memory_order_relaxed);
+                } else if (key == "auto_mode") {
+                    m_srvAutoMode.store(value == "1" || value == "true", std::memory_order_relaxed);
+                } else if (key == "stylus_vhf_enabled") {
+                    m_srvStylusVhfEnabled.store(value == "1" || value == "true", std::memory_order_relaxed);
+                }
+            }
         } else if (section == "TouchPipeline") {
             m_pipeline.LoadConfig(key, value);
         } else if (section == "StylusPipeline") {
@@ -114,23 +218,19 @@ void ServiceProxy::LoadConfig() {
     }
 }
 
-void ServiceProxy::NotifyConfigDirty() {
-    m_configDirty.SetDirty();
-}
-
 void ServiceProxy::SetSrvModeFull(bool full) {
     if (!IsLiveControlAllowed()) return;
-    m_srvModeFull = full;
+    m_srvDesiredModeFull.store(full, std::memory_order_relaxed);
 }
 
 void ServiceProxy::SetSrvStylusVhfEnabled(bool enabled) {
     if (!IsLiveControlAllowed()) return;
-    m_srvStylusVhfEnabled = enabled;
+    m_srvStylusVhfEnabled.store(enabled, std::memory_order_relaxed);
 }
 
 void ServiceProxy::SetSrvAutoMode(bool enabled) {
     if (!IsLiveControlAllowed()) return;
-    m_srvAutoMode = enabled;
+    m_srvAutoMode.store(enabled, std::memory_order_relaxed);
 }
 
 // ── MasterParser-only mode (local) ──

--- a/Tools/EGoTouchApp/source/ServiceProxy.Connection.cpp
+++ b/Tools/EGoTouchApp/source/ServiceProxy.Connection.cpp
@@ -22,10 +22,7 @@ bool ServiceProxy::Connect() {
         LOG_ERROR("App", __func__, "IPC", "Failed to open shared memory (Service not running?).");
         return false;
     }
-    // 2. Open config dirty flag
-    m_configDirty.Open();
-
-    // 3. Connect pipe to Service
+    // 2. Connect pipe to Service
     if (!m_client.Connect(3000)) {
         LOG_ERROR("App", __func__, "IPC", "Pipe connection failed.");
         m_frameReader.Close();
@@ -39,6 +36,8 @@ bool ServiceProxy::Connect() {
         m_frameReader.Close();
         return false;
     }
+
+    LoadConfig();
 
     // 4.1 Pull dynamic debug schema (best effort)
     if (!RefreshDynamicDebugSchema()) {
@@ -96,7 +95,6 @@ void ServiceProxy::Disconnect() {
         m_client.Disconnect();
     }
     m_frameReader.Close();
-    m_configDirty.Close();
     m_fps.store(0);
     m_slaveFps.store(0);
     LOG_INFO("App", __func__, "IPC", "Disconnected.");


### PR DESCRIPTION
## Summary
- add canonical IPC config control path: GetConfigSnapshot / ApplyConfigPatch / PersistConfig
- align ServiceHost, DeviceRuntime, and ServiceProxy around service-owned desired/active config semantics
- update shared frame IPC conversion path and keep legacy reload/save compatibility

## Test plan
- [x] cmake --build build --config Release --target Common EGoTouchService EGoTouchApp ServiceProxyConfigMergeTest TouchPipelineConfigRoundTripTest
- [x] ctest --test-dir build -R "ServiceProxyConfigMergeTest|TouchPipelineConfigRoundTripTest" --output-on-failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)