### PR TITLE
feat: normalize system state lifecycle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ if (EGO_BUILD_TESTS)
     target_link_libraries(StylusPipelineFastInkTest PRIVATE Solvers Common)
 
     add_test(NAME CommonLoggerTest COMMAND CommonLoggerTest)
+    add_test(NAME HostSystemStateMonitorTest COMMAND HostSystemStateMonitorTest)
     add_test(NAME TouchTrackerSilentGapTest COMMAND TouchTrackerSilentGapTest)
     add_test(NAME TouchTrackerStylusSuppressTest COMMAND TouchTrackerStylusSuppressTest)
     add_test(NAME TouchPipelineConfigRoundTripTest COMMAND TouchPipelineConfigRoundTripTest)

--- a/EGoTouchService/Host/SystemStateEvent.h
+++ b/EGoTouchService/Host/SystemStateEvent.h
@@ -6,6 +6,8 @@
 
 namespace Host {
 
+// Authoritative normalized runtime-facing semantics.
+// Transport-level named events may alias to the same normalized event.
 enum class SystemStateEventType : uint8_t {
     Unknown = 0,
     DisplayOn,
@@ -16,6 +18,11 @@ enum class SystemStateEventType : uint8_t {
     ResumeAutomatic,
 };
 
+inline constexpr std::size_t kSystemStateEventTypeCount =
+    static_cast<std::size_t>(SystemStateEventType::ResumeAutomatic) + 1;
+
+// Named events are a transport compatibility surface.
+// Multiple named events may map to the same normalized SystemStateEventType.
 enum class SystemStateNamedEventId : uint8_t {
     MonitorPowerOn = 0,
     MonitorPowerOff,
@@ -28,28 +35,38 @@ enum class SystemStateNamedEventId : uint8_t {
     Count,
 };
 
+enum class SystemStateTransportRole : uint8_t {
+    Canonical = 0,
+    LegacyAlias = 1,
+};
+
 struct SystemStateNamedEventSpec {
     SystemStateNamedEventId id = SystemStateNamedEventId::MonitorPowerOn;
     const wchar_t* name = L"";
     SystemStateEventType type = SystemStateEventType::Unknown;
+    SystemStateTransportRole transportRole = SystemStateTransportRole::Canonical;
 };
 
 inline constexpr size_t kSystemStateNamedEventCount =
     static_cast<size_t>(SystemStateNamedEventId::Count);
 
 inline constexpr SystemStateNamedEventSpec kSystemStateNamedEventSpecs[kSystemStateNamedEventCount] = {
-    {SystemStateNamedEventId::MonitorPowerOn, L"Global\\MonitorPowerOnEvent", SystemStateEventType::DisplayOn},
-    {SystemStateNamedEventId::MonitorPowerOff, L"Global\\MonitorPowerOffEvent", SystemStateEventType::DisplayOff},
-    {SystemStateNamedEventId::MonitorConsoleDisplayOn, L"Global\\MonitorConsoleDisplayOnEvent", SystemStateEventType::DisplayOn},
-    {SystemStateNamedEventId::MonitorConsoleDisplayOff, L"Global\\MonitorConsoleDisplayOffEvent", SystemStateEventType::DisplayOff},
-    {SystemStateNamedEventId::MonitorLidOn, L"Global\\MonitorLidOnEvent", SystemStateEventType::LidOn},
-    {SystemStateNamedEventId::MonitorLidOff, L"Global\\MonitorLidOffEvent", SystemStateEventType::LidOff},
-    {SystemStateNamedEventId::MonitorShutDown, L"Global\\MonitorShutDownEvent", SystemStateEventType::Shutdown},
-    {SystemStateNamedEventId::PbtApmResumeAutomatic, L"Global\\PBT_APMRESUMEAUTOMATIC", SystemStateEventType::ResumeAutomatic},
+    {SystemStateNamedEventId::MonitorPowerOn, L"Global\\MonitorPowerOnEvent", SystemStateEventType::DisplayOn, SystemStateTransportRole::LegacyAlias},
+    {SystemStateNamedEventId::MonitorPowerOff, L"Global\\MonitorPowerOffEvent", SystemStateEventType::DisplayOff, SystemStateTransportRole::LegacyAlias},
+    {SystemStateNamedEventId::MonitorConsoleDisplayOn, L"Global\\MonitorConsoleDisplayOnEvent", SystemStateEventType::DisplayOn, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::MonitorConsoleDisplayOff, L"Global\\MonitorConsoleDisplayOffEvent", SystemStateEventType::DisplayOff, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::MonitorLidOn, L"Global\\MonitorLidOnEvent", SystemStateEventType::LidOn, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::MonitorLidOff, L"Global\\MonitorLidOffEvent", SystemStateEventType::LidOff, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::MonitorShutDown, L"Global\\MonitorShutDownEvent", SystemStateEventType::Shutdown, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::PbtApmResumeAutomatic, L"Global\\PBT_APMRESUMEAUTOMATIC", SystemStateEventType::ResumeAutomatic, SystemStateTransportRole::Canonical},
 };
 
 constexpr size_t ToIndex(SystemStateNamedEventId id) noexcept {
     return static_cast<size_t>(id);
+}
+
+constexpr std::size_t ToIndex(SystemStateEventType type) noexcept {
+    return static_cast<std::size_t>(type);
 }
 
 constexpr const SystemStateNamedEventSpec* TryGetNamedEventSpec(SystemStateNamedEventId id) noexcept {
@@ -67,6 +84,16 @@ constexpr const SystemStateNamedEventSpec* TryGetNamedEventSpec(size_t index) no
     return &kSystemStateNamedEventSpecs[index];
 }
 
+constexpr bool IsCanonicalTransportEvent(SystemStateNamedEventId id) noexcept {
+    const auto* spec = TryGetNamedEventSpec(id);
+    return spec != nullptr && spec->transportRole == SystemStateTransportRole::Canonical;
+}
+
+constexpr bool IsLegacyTransportAlias(SystemStateNamedEventId id) noexcept {
+    const auto* spec = TryGetNamedEventSpec(id);
+    return spec != nullptr && spec->transportRole == SystemStateTransportRole::LegacyAlias;
+}
+
 enum class SystemStateEventSource : uint8_t {
     ThpServiceNamedEvent = 0,
 };
@@ -82,4 +109,3 @@ struct SystemStateEvent {
 const char* ToString(SystemStateEventType type) noexcept;
 
 } // namespace Host
-

--- a/EGoTouchService/Host/SystemStateMonitor.cpp
+++ b/EGoTouchService/Host/SystemStateMonitor.cpp
@@ -21,6 +21,9 @@ struct SystemStateMonitor::Impl {
     EventCallback callback;
     std::thread worker;
     std::atomic<bool> running{false};
+    SystemStateEventType lastDisplayType = SystemStateEventType::Unknown;
+    SystemStateEventType lastLidType = SystemStateEventType::Unknown;
+    bool shutdownObserved = false;
 };
 
 namespace {
@@ -101,6 +104,65 @@ SystemStateMonitor::~SystemStateMonitor() {
 
 namespace {
 
+constexpr std::size_t kInvalidBatchPosition = static_cast<std::size_t>(-1);
+
+const char* ToString(SystemStateTransportRole role) noexcept {
+    switch (role) {
+    case SystemStateTransportRole::Canonical:
+        return "canonical";
+    case SystemStateTransportRole::LegacyAlias:
+        return "legacy_alias";
+    default:
+        return "unknown";
+    }
+}
+
+bool IsDisplayStateEvent(SystemStateEventType type) noexcept {
+    return type == SystemStateEventType::DisplayOn ||
+           type == SystemStateEventType::DisplayOff;
+}
+
+bool IsLidStateEvent(SystemStateEventType type) noexcept {
+    return type == SystemStateEventType::LidOn ||
+           type == SystemStateEventType::LidOff;
+}
+
+template <typename ImplT>
+void ResetNormalizationState(ImplT& impl) noexcept {
+    impl.lastDisplayType = SystemStateEventType::Unknown;
+    impl.lastLidType = SystemStateEventType::Unknown;
+    impl.shutdownObserved = false;
+}
+
+template <typename ImplT>
+bool ShouldSuppressNormalizedEvent(const ImplT& impl, SystemStateEventType type) noexcept {
+    if (IsDisplayStateEvent(type)) {
+        return impl.lastDisplayType == type;
+    }
+    if (IsLidStateEvent(type)) {
+        return impl.lastLidType == type;
+    }
+    if (type == SystemStateEventType::Shutdown) {
+        return impl.shutdownObserved;
+    }
+    return false;
+}
+
+template <typename ImplT>
+void RememberNormalizedEvent(ImplT& impl, SystemStateEventType type) noexcept {
+    if (IsDisplayStateEvent(type)) {
+        impl.lastDisplayType = type;
+        return;
+    }
+    if (IsLidStateEvent(type)) {
+        impl.lastLidType = type;
+        return;
+    }
+    if (type == SystemStateEventType::Shutdown) {
+        impl.shutdownObserved = true;
+    }
+}
+
 SystemStateEvent BuildEvent(std::size_t index) {
     SystemStateEvent event{};
     event.source = SystemStateEventSource::ThpServiceNamedEvent;
@@ -117,6 +179,144 @@ SystemStateEvent BuildEvent(std::size_t index) {
     }
 
     return event;
+}
+
+struct NormalizedBatchEntry {
+    bool present = false;
+    std::size_t firstPosition = kInvalidBatchPosition;
+    SystemStateEvent event{};
+    SystemStateTransportRole transportRole = SystemStateTransportRole::Canonical;
+};
+
+bool ShouldPreferTransportRole(SystemStateTransportRole current, SystemStateTransportRole candidate) noexcept {
+    return current != SystemStateTransportRole::Canonical &&
+           candidate == SystemStateTransportRole::Canonical;
+}
+
+template <typename ImplT>
+std::size_t CollectSignaledEventBatch(
+    ImplT& impl,
+    std::size_t firstEventIndex,
+    std::array<std::size_t, SystemStateMonitor::kEventCount>& batchIndices) noexcept {
+    std::size_t batchCount = 0;
+    batchIndices[batchCount++] = firstEventIndex;
+
+    for (std::size_t i = 0; i < SystemStateMonitor::kEventCount; ++i) {
+        if (i == firstEventIndex) {
+            continue;
+        }
+
+        HANDLE eventHandle = impl.events[i];
+        if (eventHandle == nullptr || eventHandle == INVALID_HANDLE_VALUE) {
+            continue;
+        }
+
+        if (WaitForSingleObject(eventHandle, 0) == WAIT_OBJECT_0) {
+            batchIndices[batchCount++] = i;
+        }
+    }
+
+    return batchCount;
+}
+
+template <typename ImplT>
+void ResetSignaledEvents(
+    ImplT& impl,
+    const std::array<std::size_t, SystemStateMonitor::kEventCount>& batchIndices,
+    std::size_t batchCount) noexcept {
+    for (std::size_t i = 0; i < batchCount; ++i) {
+        HANDLE eventHandle = impl.events[batchIndices[i]];
+        if (eventHandle != nullptr && eventHandle != INVALID_HANDLE_VALUE) {
+            ResetEvent(eventHandle);
+        }
+    }
+}
+
+template <typename ImplT>
+void DispatchNormalizedBatch(
+    ImplT& impl,
+    const std::array<std::size_t, SystemStateMonitor::kEventCount>& batchIndices,
+    std::size_t batchCount) {
+    std::array<NormalizedBatchEntry, kSystemStateEventTypeCount> entries{};
+
+    for (std::size_t position = 0; position < batchCount; ++position) {
+        const std::size_t eventIndex = batchIndices[position];
+        const SystemStateNamedEventSpec* spec = TryGetNamedEventSpec(eventIndex);
+        SystemStateEvent event = BuildEvent(eventIndex);
+        NormalizedBatchEntry& entry = entries[ToIndex(event.type)];
+
+        if (!entry.present) {
+            entry.present = true;
+            entry.firstPosition = position;
+            entry.event = event;
+            if (spec != nullptr) {
+                entry.transportRole = spec->transportRole;
+            }
+            continue;
+        }
+
+        if (spec != nullptr && ShouldPreferTransportRole(entry.transportRole, spec->transportRole)) {
+            const auto firstTimestamp = entry.event.timestamp;
+            entry.event = event;
+            entry.event.timestamp = firstTimestamp;
+            entry.transportRole = spec->transportRole;
+        }
+    }
+
+    for (std::size_t position = 0; position < batchCount; ++position) {
+        const std::size_t eventIndex = batchIndices[position];
+        const SystemStateNamedEventSpec* spec = TryGetNamedEventSpec(eventIndex);
+        const SystemStateEventType type = spec != nullptr ? spec->type : SystemStateEventType::Unknown;
+        const NormalizedBatchEntry& entry = entries[ToIndex(type)];
+
+        if (!entry.present) {
+            continue;
+        }
+
+        if (entry.firstPosition != position) {
+            LOG_INFO(
+                "Host",
+                __func__,
+                "Normalize",
+                "Suppressing named event[{}] as duplicate transport for type={}.",
+                eventIndex,
+                ToString(type));
+            continue;
+        }
+
+        if (ShouldSuppressNormalizedEvent(impl, entry.event.type)) {
+            LOG_INFO(
+                "Host",
+                __func__,
+                "Normalize",
+                "Suppressing normalized duplicate type={} from named event[{}] (role={}).",
+                ToString(entry.event.type),
+                entry.event.raw_index,
+                ToString(entry.transportRole));
+            continue;
+        }
+
+        LOG_INFO(
+            "Host",
+            __func__,
+            "Signal",
+            "Named event[{}] normalized -> type={} (role={}).",
+            entry.event.raw_index,
+            ToString(entry.event.type),
+            ToString(entry.transportRole));
+
+        RememberNormalizedEvent(impl, entry.event.type);
+
+        if (impl.callback) {
+            try {
+                impl.callback(entry.event);
+            } catch (const std::exception& ex) {
+                LOG_ERROR("Host", __func__, "Callback", "SystemStateMonitor callback threw std::exception: {}", ex.what());
+            } catch (...) {
+                LOG_ERROR("Host", __func__, "Callback", "SystemStateMonitor callback threw unknown exception.");
+            }
+        }
+    }
 }
 
 template <typename ImplT>
@@ -169,26 +369,11 @@ void WorkerLoop(ImplT& impl) {
 
         if (wait_result >= WAIT_OBJECT_0 + 1 &&
             wait_result < WAIT_OBJECT_0 + 1 + SystemStateMonitor::kEventCount) {
-            const std::size_t event_index = static_cast<std::size_t>(wait_result - WAIT_OBJECT_0 - 1);
-            SystemStateEvent event = BuildEvent(event_index);
-
-            LOG_INFO("Host", __func__, "Signal", "Named event[{}] signaled → type={}", event_index, ToString(event.type));
-
-            if (impl.callback) {
-                try {
-                    impl.callback(event);
-                } catch (const std::exception& ex) {
-                    LOG_ERROR("Host", __func__, "Callback", "SystemStateMonitor callback threw std::exception: {}", ex.what());
-                } catch (...) {
-                    LOG_ERROR("Host", __func__, "Callback", "SystemStateMonitor callback threw unknown exception.");
-                }
-            }
-
-            HANDLE event_handle = impl.events[event_index];
-            if (event_handle != nullptr && event_handle != INVALID_HANDLE_VALUE) {
-                ResetEvent(event_handle);
-            }
-
+            const std::size_t firstEventIndex = static_cast<std::size_t>(wait_result - WAIT_OBJECT_0 - 1);
+            std::array<std::size_t, SystemStateMonitor::kEventCount> batchIndices{};
+            const std::size_t batchCount = CollectSignaledEventBatch(impl, firstEventIndex, batchIndices);
+            DispatchNormalizedBatch(impl, batchIndices, batchCount);
+            ResetSignaledEvents(impl, batchIndices, batchCount);
             continue;
         }
 
@@ -224,6 +409,7 @@ bool SystemStateMonitor::Start(EventCallback callback) {
         return false;
     }
 
+    ResetNormalizationState(impl);
     impl.callback = std::move(callback);
     impl.stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     if (impl.stopEvent == nullptr) {

--- a/EGoTouchService/include/ServiceShell.h
+++ b/EGoTouchService/include/ServiceShell.h
@@ -38,7 +38,9 @@ private:
     static DWORD WINAPI SvcCtrlHandlerEx(
         DWORD ctrl, DWORD evtType,
         LPVOID evtData, LPVOID ctx);
+    static BOOL WINAPI ConsoleCtrlHandler(DWORD ctrlType);
 
+    void SignalShutdownTransportAndStop() noexcept;
     void RegisterPowerNotifications();
     void UnregisterPowerNotifications();
     void ReportStatus(DWORD state, DWORD waitHint = 0);

--- a/EGoTouchService/source/ServiceShell.cpp
+++ b/EGoTouchService/source/ServiceShell.cpp
@@ -77,9 +77,8 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
     case SERVICE_CONTROL_SHUTDOWN:
     case SERVICE_CONTROL_PRESHUTDOWN:
         LOG_INFO("Service", __func__, "Stopping", "Received stop/shutdown control code={}.", ctrl);
-        signalEvent(Host::SystemStateNamedEventId::MonitorShutDown);
+        s->SignalShutdownTransportAndStop();
         s->ReportStatus(SERVICE_STOP_PENDING, 5000);
-        SetEvent(s->m_impl->stopEvent);
         return NO_ERROR;
 
     case SERVICE_CONTROL_POWEREVENT: {
@@ -135,13 +134,31 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
 
 // ─── 控制台模式 ──────────────────────────────
 
+BOOL WINAPI ServiceShell::ConsoleCtrlHandler(DWORD ctrlType) {
+    switch (ctrlType) {
+    case CTRL_C_EVENT:
+    case CTRL_BREAK_EVENT:
+    case CTRL_CLOSE_EVENT:
+    case CTRL_LOGOFF_EVENT:
+    case CTRL_SHUTDOWN_EVENT:
+        Instance()->SignalShutdownTransportAndStop();
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+void ServiceShell::SignalShutdownTransportAndStop() noexcept {
+    Host::SystemStateMonitor::SignalNamedEvent(Host::SystemStateNamedEventId::MonitorShutDown);
+    if (m_impl != nullptr && m_impl->stopEvent != nullptr) {
+        SetEvent(m_impl->stopEvent);
+    }
+}
+
 void ServiceShell::RunAsConsole() {
     m_impl->stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    SetConsoleCtrlHandler([](DWORD) -> BOOL {
-        SetEvent(Instance()->m_impl->stopEvent);
-        return TRUE;
-    }, TRUE);
+    SetConsoleCtrlHandler(&ServiceShell::ConsoleCtrlHandler, TRUE);
 
     LOG_INFO("Service", __func__, "Boot", "Starting modules (console mode)...");
     if (!m_impl->host.Start()) {


### PR DESCRIPTION
## Summary
- normalize named-event based system state signals and suppress duplicate transports
- route lifecycle handling through ServiceShell + monitor flow with clearer shutdown/resume behavior
- register and maintain HostSystemStateMonitor test coverage

## Test plan
- [x] cmake --build build --config Release --target HostSystemStateMonitorTest EGoTouchService
- [x] ctest --test-dir build -R "HostSystemStateMonitorTest" --output-on-failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)