### PR TITLE
feat: refine stylus and touch solver behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ if (EGO_BUILD_TESTS)
     target_link_libraries(StylusPipelineFastInkTest PRIVATE Solvers Common)
 
     add_test(NAME CommonLoggerTest COMMAND CommonLoggerTest)
+    add_test(NAME HostSystemStateMonitorTest COMMAND HostSystemStateMonitorTest)
     add_test(NAME TouchTrackerSilentGapTest COMMAND TouchTrackerSilentGapTest)
     add_test(NAME TouchTrackerStylusSuppressTest COMMAND TouchTrackerStylusSuppressTest)
     add_test(NAME TouchPipelineConfigRoundTripTest COMMAND TouchPipelineConfigRoundTripTest)

--- a/EGoTouchService/Device/himax/HimaxChipFrame.cpp
+++ b/EGoTouchService/Device/himax/HimaxChipFrame.cpp
@@ -6,6 +6,54 @@
 #include <thread>
 #include <chrono>
 
+namespace {
+
+constexpr auto kIdleProbeInterval = std::chrono::milliseconds{50};
+constexpr uint32_t kIdleEntryThreshold = 600;
+
+ChipResult<> ReadFrameBuffer(Himax::HalDevice* dev,
+                             void* buffer,
+                             uint32_t sizeBytes,
+                             const char* logFunc,
+                             const char* chipState,
+                             const char* deviceName,
+                             bool logFailures) {
+    if (!dev || !dev->IsValid()) {
+        if (logFailures) {
+            LOG_ERROR("HimaxChip", logFunc, chipState, "{} handle invalid", deviceName);
+        }
+        return std::unexpected(ChipError::CommunicationError);
+    }
+
+    if (auto res = dev->GetFrame(buffer, sizeBytes, nullptr); !res) {
+        if (dev->IsTimeoutError()) {
+            return std::unexpected(ChipError::Timeout);
+        }
+        if (logFailures) {
+            LOG_ERROR("HimaxChip", logFunc, chipState, "{} GetFrame failed!", deviceName);
+        }
+        return res;
+    }
+
+    return {};
+}
+
+bool ShouldSkipMasterRead(uint32_t frameCount, bool stylusActive) noexcept {
+    return ((frameCount & 1u) != 0u) && stylusActive;
+}
+
+bool ShouldEnterIdle(uint32_t& zeroFrameCount, bool inputDetected) noexcept {
+    if (inputDetected) {
+        zeroFrameCount = 0;
+        return false;
+    }
+
+    ++zeroFrameCount;
+    return zeroFrameCount >= kIdleEntryThreshold;
+}
+
+} // anonymous namespace
+
 namespace Himax {
 
 ChipResult<> Chip::SetFrameReadPolicy(bool block, uint8_t timeoutMs) {
@@ -74,64 +122,66 @@ ChipResult<> Chip::GetFrame(void) {
     constexpr uint32_t kSlaveFrameBytes = static_cast<uint32_t>(Frame::kSlaveFrameSize);
     constexpr size_t kSlaveFrameOffset = static_cast<size_t>(Frame::kSlaveHeaderOffset);
 
-    // Idle: periodic probe only
+    auto readMaster = [&](bool logFailures) -> ChipResult<> {
+        return ReadFrameBuffer(m_master.get(),
+                               back_data.data(),
+                               kMasterFrameBytes,
+                               __func__,
+                               GetStateStr(),
+                               "Master",
+                               logFailures);
+    };
+
+    auto readSlave = [&](bool logFailures) -> ChipResult<> {
+        return ReadFrameBuffer(m_slave.get(),
+                               back_data.data() + kSlaveFrameOffset,
+                               kSlaveFrameBytes,
+                               __func__,
+                               GetStateStr(),
+                               "Slave",
+                               logFailures);
+    };
+
     if (afe_mode.load() == THP_AFE_MODE::Idle) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::this_thread::sleep_for(kIdleProbeInterval);
 
-        auto m_res = m_master->GetFrame(back_data.data(), kMasterFrameBytes, nullptr);
-        auto s_res = m_slave->GetFrame(back_data.data() + kSlaveFrameOffset, kSlaveFrameBytes, nullptr);
+        const auto masterRes = readMaster(false);
+        const auto slaveRes = readSlave(false);
 
-        if (m_res && s_res) {
-            if (isFingerDetected() || isStylusDetected()) {
-                (void)NotifyTouchWakeup();
-                LOG_INFO("HimaxChip", __func__, GetStateStr(), "Input detected in idle → wakeup to Normal");
-            }
-            return std::unexpected(ChipError::Timeout);
+        if (masterRes && slaveRes && (isFingerDetected() || isStylusDetected())) {
+            (void)NotifyTouchWakeup();
+            LOG_INFO("HimaxChip", __func__, GetStateStr(), "Input detected in idle → wakeup to Normal");
         }
+
         return std::unexpected(ChipError::Timeout);
     }
 
-    const bool skipMaster = (m_frameCount & 1) != 0 && m_stylusActive;
+    const bool skipMaster = ShouldSkipMasterRead(m_frameCount, m_stylusActive);
 
-    if (auto res = m_slave->GetFrame(back_data.data() + kSlaveFrameOffset, kSlaveFrameBytes, nullptr); !res) {
-        if (m_slave->IsTimeoutError())
-            return std::unexpected(ChipError::Timeout);
-        LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Slave GetFrame failed!");
+    if (auto res = readSlave(true); !res) {
         return res;
     }
 
     if (!skipMaster) {
-        if (auto res = m_master->GetFrame(back_data.data(), kMasterFrameBytes, nullptr); !res) {
-            if (m_master->IsTimeoutError())
-                return std::unexpected(ChipError::Timeout);
-            LOG_ERROR("HimaxChip", __func__, GetStateStr(), "Master GetFrame failed!");
+        if (auto res = readMaster(true); !res) {
             return res;
         }
     }
 
     m_lastMasterWasRead = !skipMaster;
-    m_frameCount++;
+    ++m_frameCount;
 
+    const bool fingerNow = isFingerDetected();
     const bool stylusNow = isStylusDetected();
-    if (stylusNow && !m_stylusActive) {
-        m_stylusActive = true;
-    } else if (!stylusNow && m_stylusActive) {
+    m_stylusActive = stylusNow;
+
+    if (ShouldEnterIdle(m_zeroFrameCount, fingerNow || stylusNow)) {
+        LOG_INFO("HimaxChip", __func__, GetStateStr(), "No input for {} frames → EnterIdle", m_zeroFrameCount);
         m_stylusActive = false;
-    }
-
-    constexpr uint32_t kIdleEntryThreshold = 600;
-
-    if (isFingerDetected() || stylusNow) {
+        (void)m_afe.EnterIdle();
         m_zeroFrameCount = 0;
-    } else {
-        m_zeroFrameCount++;
-        if (m_zeroFrameCount >= kIdleEntryThreshold) {
-            LOG_INFO("HimaxChip", __func__, GetStateStr(), "No input for {} frames → EnterIdle", m_zeroFrameCount);
-            m_stylusActive = false;
-            (void)m_afe.EnterIdle();
-            m_zeroFrameCount = 0;
-        }
     }
+
     return {};
 }
 

--- a/EGoTouchService/Device/himax/HimaxChipLifecycle.cpp
+++ b/EGoTouchService/Device/himax/HimaxChipLifecycle.cpp
@@ -318,6 +318,12 @@ ChipResult<> Chip::Init(void) {
         return res;
     }
 
+    current_slot = 0;
+    m_zeroFrameCount = 0;
+    m_frameCount = 0;
+    m_stylusActive = false;
+    m_lastMasterWasRead = true;
+    afe_mode.store(THP_AFE_MODE::Normal);
     m_connState.store(ConnectionState::Connected);
 
     m_afe.ResetStylusState();
@@ -339,8 +345,15 @@ ChipResult<> Chip::Init(void) {
 }
 
 ChipResult<> Chip::Deinit(bool check_en) {
-    m_connState.store(ConnectionState::Unconnected);
     LOG_INFO("HimaxChip", __func__, GetStateStr(), "Starting Deinit sequence...");
+    m_connState.store(ConnectionState::Unconnected);
+    afe_mode.store(THP_AFE_MODE::Normal);
+    m_zeroFrameCount = 0;
+    m_frameCount = 0;
+    m_stylusActive = false;
+    m_lastMasterWasRead = true;
+    current_slot = 0;
+    m_afe.ResetStylusState();
 
     auto resOff = hx_sense_off(check_en);
     if (!resOff) {
@@ -360,6 +373,13 @@ ChipResult<> Chip::Deinit(bool check_en) {
 
 void Chip::HoldReset() {
     m_connState.store(ConnectionState::Unconnected);
+    afe_mode.store(THP_AFE_MODE::Normal);
+    m_zeroFrameCount = 0;
+    m_frameCount = 0;
+    m_stylusActive = false;
+    m_lastMasterWasRead = true;
+    current_slot = 0;
+    m_afe.ResetStylusState();
 
     CancelPendingFrameRead();
 

--- a/EGoTouchService/Device/penevt/BTMCU_PROTOCOL.md
+++ b/EGoTouchService/Device/penevt/BTMCU_PROTOCOL.md
@@ -1,0 +1,216 @@
+# BTMCU USB 协议表
+
+基于以下来源整理：
+- `THP_Service.dll` 的 Ghidra MCP 逆向结果
+- `EGoTouchService/Device/penevt/PenEventBridge.cpp`
+- 当前桥接层已落地的 exact factory capture
+
+> 置信度标记
+> - **Confirmed**: 已被反汇编/反编译或当前代码中的 exact capture 明确证实
+> - **Likely**: 高概率成立，但还缺少抓包或更深层调用链确认
+> - **Open**: 仍待确认
+
+## 1. 报文骨架
+
+### 1.1 Host → MCU 发送帧（Confirmed）
+所有已确认的主机发包最终都走 `BtPen_SendPacket @ 0x18000f500`，其行为是：
+- 拷贝 8 字节 header
+- 强制 `byte[6] = 0x11`
+- 从 `byte[8]` 开始追加 payload
+- 调用 `WriteFile(handle, buf, payload_len + 8, ...)`
+
+已确认的发送帧布局：
+
+| 偏移 | 含义 | 备注 |
+|---|---|---|
+| `byte[0]` | `0x07` | 固定 |
+| `byte[1]` | 子类型/标志 | 见命令表，已观测到 `0x00 / 0x01` |
+| `byte[2]` | `0x02` | 固定 |
+| `byte[3]` | `0x00` | 目前观测固定为 0 |
+| `byte[4]` | 命令低字节 | 已观测均为 `0x01` |
+| `byte[5]` | 命令高字节 | 如 `0x71 / 0x77 / 0x7D / 0x7E / 0x80` |
+| `byte[6]` | `0x11` | `BtPen_SendPacket` 强制覆盖 |
+| `byte[7]` | 类型字节 | 已观测到 `0x00 / 0x01 / 0x20` |
+| `byte[8..]` | payload | 可空 |
+
+### 1.2 MCU → Host 接收帧（部分 Confirmed）
+`AsynchReadThreadProc @ 0x18000e1d0` 持续 `ReadFile(..., 0x40)`，并把 64 字节包推进环形队列。
+
+在 `USB_AsynchProcThreadProc @ 0x18000cf40` 中，已确认：
+- 事件码来自 `packet[5]`
+- 多数事件的首个有效载荷字节来自 `packet[8]`
+- 接收线程会校验 `packet[4] == 0x01`
+
+其余接收头字段语义仍待抓包与更深层验证。
+
+---
+
+## 2. Host → MCU 命令表
+
+| 命令 | 方向 | 头部示例 | Payload | 触发点 | 结论 |
+|---|---|---|---|---|---|
+| `0x7101` | Host → MCU | `07 00 02 00 01 71 11 00` | 无 | `BtPen_CheckPenStatus @ 0x18000e830` | **Confirmed** |
+| `0x7701` | Host → MCU | `07 00 02 00 01 77 11 00` | 无 | `BtPen_CheckMcuStatus @ 0x18000e8c0` | **Confirmed** |
+| `0x8001` | Host → MCU | `07 01 02 00 01 80 11 20` | 1 字节 ACK code | `BtPen_SendEventAck @ 0x180011d20` | **Confirmed** |
+| `0x7E01` | Host → MCU | `07 01 02 00 01 7E 11 01` | 1 字节 | `BtPen_GetReportInfo @ 0x18000e960`，type=4 | **Confirmed** |
+| `0x7D01` | Host → MCU | `07 01 02 00 01 7D 11 20` | 32 字节 | `BtPen_HandleInitParamEvent @ 0x18000f660`，type=2 | **Confirmed** |
+
+### 2.1 `0x8001` ACK 包（Confirmed）
+`BtPen_SendEventAck` 的 payload 只有 1 字节，即 ACK code。
+
+示例：
+```text
+07 01 02 00 01 80 11 20 <ack_code>
+```
+
+### 2.2 `0x7E01` Match-Info 响应（Confirmed）
+`BtPen_GetReportInfo(type=4)` 会发送 1 字节 payload，来源于 `param_1[1]`。
+
+示例：
+```text
+07 01 02 00 01 7E 11 01 <value>
+```
+
+### 2.3 `0x7D01` Init-Param 响应（Confirmed）
+`BtPen_HandleInitParamEvent` 会把一段 32 字节 ASCII/CSV 参数串转换成 32 字节二进制，然后发出：
+
+```text
+07 01 02 00 01 7D 11 20 <32-byte payload>
+```
+
+---
+
+## 3. MCU → Host 事件表
+
+| 事件码 (`packet[5]`) | 名称/日志 | Host 处理 | ACK code | 结论 |
+|---|---|---|---:|---|
+| `0x03` | `USBD_SW_VERSION` | 记录日志 | 无 | **Confirmed** |
+| `0x08` | `BATTERY_STATUS` | 记录日志 | 无 | **Confirmed** |
+| `0x09` | `CHARGING_STATUS` | 记录日志 | 无 | **Confirmed** |
+| `0x10` | `DEV_CONNECT` | 记录日志 | 无 | **Confirmed** |
+| `0x12` | `DEV_PAIR_STATUS` | 更新状态 | 无 | **Confirmed** |
+| `0x21` | `PEN_DOCK_STATUS` | 记录日志 | 无 | **Confirmed** |
+| `0x23` | `PEN_UPDATE_STATUS` | 记录日志 | 无 | **Confirmed** |
+| `0x27` | `PEN_KEY_FUNC_GET` | 记录日志 | 无 | **Confirmed** |
+| `0x2C` | `PEN_BATTERY_AFTER_CONN` | 记录日志 | 无 | **Confirmed** |
+| `0x2E` | `PEN_PAIR_DETECT_ACK` | 记录日志 | 无 | **Confirmed** |
+| `0x2F` | `PEN_CURRENT_FUNC` | 更新当前功能 | `0x0B` | **Confirmed** |
+| `0x70` | `PEN_AC_STATUS` | 更新状态位 | `0x00` | **Confirmed** |
+| `0x71` | `PEN_CONN_STATUS` | 更新连接状态 | `0x01` | **Confirmed** |
+| `0x72` | `PEN_CUR_STATUS` | 更新当前模式 | `0x02` | **Confirmed** |
+| `0x73` | `PEN_TYPE_INFO` | 更新笔类型/ID | `0x0D` | **Confirmed** |
+| `0x74` | `PEN_ROATE_ANGLE` | 更新旋转角 | `0x03` | **Confirmed** |
+| `0x75` | `PEN_TOUCH_MODE` | 更新 touch mode | `0x04` | **Confirmed** |
+| `0x76` | `PEN_GLOBAL_PREVENT_MODE` | 更新 prevent mode | `0x05` | **Confirmed** |
+| `0x77` | 未命名事件 | 仅回 ACK | `0x06` | **Confirmed** |
+| `0x78` | `PEN_HOLSTER` | 更新 holster | `0x07` | **Confirmed** |
+| `0x79` | `PEN_FREQ_JUMP` | 记录/通知 | `0x08` | **Confirmed** |
+| `0x7B` | `PEN_REP_PARAM` | 仅记录/ACK | `0x0A` | **Confirmed** |
+| `0x7C` | `PEN_GLOBAL_ANNOTATION` | 更新注解相关状态 | `0x0C` | **Confirmed** |
+| `0x7F` | `ERASER_TOGGLE` | 更新 eraser toggle | `0x09` | **Confirmed** |
+
+---
+
+## 4. ACK 对照表
+
+| 事件码 | ACK code |
+|---|---:|
+| `0x70` | `0x00` |
+| `0x71` | `0x01` |
+| `0x72` | `0x02` |
+| `0x74` | `0x03` |
+| `0x75` | `0x04` |
+| `0x76` | `0x05` |
+| `0x77` | `0x06` |
+| `0x78` | `0x07` |
+| `0x79` | `0x08` |
+| `0x7F` | `0x09` |
+| `0x7B` | `0x0A` |
+| `0x2F` | `0x0B` |
+| `0x7C` | `0x0C` |
+| `0x73` | `0x0D` |
+
+---
+
+## 5. 0x7B / 0x7D01 专题
+
+### 5.1 `0x7B` 本身（Confirmed）
+在 `USB_AsynchProcThreadProc` 的 `case 0x7B` 中，原厂行为只有两步：
+1. 记录日志 `"[USB]PEN_REP_PARAM"`
+2. 发送 `BtPen_SendEventAck(0x0A)`
+
+**原厂并不会在这个 switch case 里直接发送 `0x7D01`。**
+
+### 5.2 `0x7D01` 的真实触发路径（Confirmed）
+`0x7D01` 来自另一条路径：
+
+```text
+ServiceInterface[+0xA8]
+  -> BtPen_GetReportInfo(type=2)
+    -> BtPen_HandleInitParamEvent(...)
+      -> BtPen_SendPacket(cmd=0x7D01, payload_len=0x20)
+```
+
+也就是说：
+- `0x7B` 是 MCU 上报事件
+- `0x7D01` 是 Host 侧稍后通过另一路 service callback 主动发回的初始化参数
+- 两者在时序上相关，但**不是同一个 switch 分支里的直接同步响应**
+
+### 5.3 当前项目中唯一已确认的 exact payload（Confirmed）
+当前代码在 `PenEventBridge.cpp:376-398` 固定发送了一份 exact factory capture：
+
+```text
+Header:
+07 01 02 00 01 7D 11 20
+
+Payload:
+33 33 33 33 E7 02 12 04 58 02 8D 20 0F 01 02 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+```
+
+这份 payload 是目前最可靠的 `0x7D01` 基线。
+
+### 5.4 用 Ghidra 中的 type-3 编码规则反推 CSV token（Confirmed）
+`BtPen_HandleInitParamEvent` 的 token 编码规则是：
+
+| token 长度 | 输出字节 |
+|---|---|
+| `1` | `[hex(d0)]` |
+| `2` | `[hex(d1), hex(d0)]` |
+| `3` | `[hex(d1d2), hex(d0)]` |
+| `4` | `[hex(d2d3), hex(d0d1)]` |
+
+按该规则反推，`PenEventBridge.cpp:385-393` 的 exact payload 对应 token 序列应为：
+
+```text
+3333,3333,2e7,412,258,208d,10f,2,
+```
+
+这与 `PenEventBridge.cpp` 里旧注释中的：
+
+```text
+3333,3333,2e7,412,258,411a,0f,1,
+```
+
+**并不一致**。因此在重新抓到更强证据前，应优先相信 exact payload，而不是旧注释字符串。
+
+---
+
+## 6. 当前项目代码对应点
+
+| 位置 | 说明 |
+|---|---|
+| `PenEventBridge.cpp:171-179` | 当前桥接层的 ACK 映射表 |
+| `PenEventBridge.cpp:187-197` | 当前桥接层 `0x8001` ACK 发送 |
+| `PenEventBridge.cpp:231-243` | 当前桥接层把首次 `0x7B` 作为触发点，发送 `0x7D01` |
+| `PenEventBridge.cpp:300-367` | 当前握手序列：`0x7101 -> 0x7701 -> 0x7701` |
+| `PenEventBridge.cpp:376-398` | 当前唯一已确认的 `0x7D01` exact factory payload |
+
+---
+
+## 7. 仍待深挖的问题
+
+1. 接收帧 `byte[0..3] / byte[6] / byte[7]` 的精确定义仍未最终命名。
+2. `0x77` 事件目前只看到 ACK，没有看见业务语义。
+3. 需要更多抓包来确认：`0x7B` 的 event payload 本身是否携带可用于选择 `0x7D01` 模板的信息。
+4. `PenEventBridge.cpp:171` 中的 `0x6F -> 0x0B` 不是原厂 Ghidra 事件表中的确认项；原厂确认的是 `0x2F -> 0x0B`。

--- a/EGoTouchService/Device/penevt/PenEventBridge.cpp
+++ b/EGoTouchService/Device/penevt/PenEventBridge.cpp
@@ -14,7 +14,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -157,7 +156,11 @@ bool PenEventBridge::SendScanMode(uint8_t freq1, uint8_t freq2, uint8_t mode) {
     pkt[7] = 0x20;   // payload tag (0x20 for payload-present commands)
     std::copy(payload, payload + 0x20, pkt.begin() + 8);
 
-    SendRawPacket(pkt);
+    if (!SendRawPacket(pkt)) {
+        LOG_WARN("PenEvent", __func__, "MCU", "SetScanMode send failed.");
+        return false;
+    }
+
     LOG_INFO("PenEvent", __func__, "MCU",
              "SetScanMode sent: freq1=0x{:02X}, freq2=0x{:02X}, mode={}"
              " → payload=[{:02X} {:02X} {:02X} {:02X} {:02X} {:02X}]",
@@ -179,9 +182,22 @@ int PenEventBridge::GetAckCode(uint8_t eventCode) {
     }
 }
 
-void PenEventBridge::SendRawPacket(const std::vector<uint8_t>& pkt) {
-    if (!IsTransportOpen()) return;
-    (void)GetTransport()->WritePacket(pkt);
+bool PenEventBridge::SendRawPacket(const std::vector<uint8_t>& pkt) {
+    std::lock_guard<std::mutex> txLock(m_txMutex);
+    if (!IsTransportOpen()) {
+        LOG_WARN("PenEvent", __func__, "MCU", "Transport not open; dropping packet send.");
+        return false;
+    }
+
+    auto result = GetTransport()->WritePacket(pkt);
+    if (!result) {
+        LOG_WARN("PenEvent", __func__, "MCU",
+                 "WritePacket failed while sending {} bytes (error={}).",
+                 pkt.size(), static_cast<int>(result.error()));
+        return false;
+    }
+
+    return true;
 }
 
 void PenEventBridge::SendAck(uint8_t ackCode) {
@@ -192,15 +208,210 @@ void PenEventBridge::SendAck(uint8_t ackCode) {
         0x07, 0x01, 0x02, 0x00,
         0x01, 0x80, 0x11, 0x20, ackCode
     };
-    SendRawPacket(pkt);
-    LOG_INFO("PenEvent", __func__, "MCU", "ACK sent: 0x{:02X}", ackCode);
+    if (SendRawPacket(pkt)) {
+        LOG_INFO("PenEvent", __func__, "MCU", "ACK sent: 0x{:02X}", ackCode);
+    }
 }
 
+void PenEventBridge::ResetSessionState() {
+    std::lock_guard<std::mutex> sessionLock(m_sessionMutex);
+    m_sessionPhase = SessionPhase::AwaitingPenStatus;
+    m_initParamSent = false;
+    m_penStatusQuerySent = false;
+    m_firstMcuStatusQuerySent = false;
+    m_secondMcuStatusQuerySent = false;
+    m_receivedPenCurStatus = false;
+    m_receivedPenTypeInfo = false;
+}
 
+bool PenEventBridge::SendQueryPenStatus() {
+    {
+        std::lock_guard<std::mutex> sessionLock(m_sessionMutex);
+        if (m_penStatusQuerySent) {
+            return false;
+        }
+    }
+
+    const std::vector<uint8_t> query = {0x07, 0x00, 0x02, 0x00, 0x01, 0x71, 0x11, 0x00};
+    if (!SendRawPacket(query)) {
+        LOG_WARN("PenEvent", __func__, "MCU", "Failed to send 0x7101 CheckPenStatus.");
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> sessionLock(m_sessionMutex);
+        if (m_penStatusQuerySent) {
+            return true;
+        }
+        m_penStatusQuerySent = true;
+        m_sessionPhase = SessionPhase::AwaitingPenStatus;
+    }
+
+    LOG_INFO("PenEvent", __func__, "MCU", "Sent 0x7101 CheckPenStatus.");
+    return true;
+}
+
+bool PenEventBridge::SendFirstMcuStatusQuery() {
+    {
+        std::lock_guard<std::mutex> sessionLock(m_sessionMutex);
+        if (m_firstMcuStatusQuerySent) {
+            return false;
+        }
+    }
+
+    const std::vector<uint8_t> query = {0x07, 0x00, 0x02, 0x00, 0x01, 0x77, 0x11, 0x00};
+    if (!SendRawPacket(query)) {
+        LOG_WARN("PenEvent", __func__, "MCU", "Failed to send first 0x7701 CheckMcuStatus.");
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> sessionLock(m_sessionMutex);
+        if (m_firstMcuStatusQuerySent) {
+            return true;
+        }
+        m_firstMcuStatusQuerySent = true;
+        m_sessionPhase = SessionPhase::AwaitingMcuStatus;
+    }
+
+    LOG_INFO("PenEvent", __func__, "MCU", "Sent 0x7701 CheckMcuStatus (#1/2).");
+    return true;
+}
+
+bool PenEventBridge::SendSecondMcuStatusQuery() {
+    {
+        std::lock_guard<std::mutex> sessionLock(m_sessionMutex);
+        if (m_secondMcuStatusQuerySent) {
+            return false;
+        }
+    }
+
+    const std::vector<uint8_t> query = {0x07, 0x00, 0x02, 0x00, 0x01, 0x77, 0x11, 0x00};
+    if (!SendRawPacket(query)) {
+        LOG_WARN("PenEvent", __func__, "MCU", "Failed to send second 0x7701 CheckMcuStatus.");
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> sessionLock(m_sessionMutex);
+        if (m_secondMcuStatusQuerySent) {
+            return true;
+        }
+        m_secondMcuStatusQuerySent = true;
+        m_sessionPhase = SessionPhase::AwaitingInitParamRequest;
+    }
+
+    LOG_INFO("PenEvent", __func__, "MCU", "Sent 0x7701 CheckMcuStatus (#2/2).");
+    return true;
+}
+
+void PenEventBridge::AdvanceSessionFromEvent(uint8_t eventCode) {
+    bool sendFirstMcuStatusQuery = false;
+    bool sendSecondMcuStatusQuery = false;
+    bool sendInitParams = false;
+    bool duplicateInitParamRequest = false;
+    bool waitingForInitParamRequest = false;
+    bool ignoredUnexpectedEvent = false;
+    SessionPhase phaseAtEvent = SessionPhase::Running;
+
+    {
+        std::lock_guard<std::mutex> sessionLock(m_sessionMutex);
+        phaseAtEvent = m_sessionPhase;
+
+        switch (m_sessionPhase) {
+        case SessionPhase::AwaitingPenStatus:
+            if (eventCode == static_cast<uint8_t>(PenUsbEventCode::PenConnStatus)) {
+                sendFirstMcuStatusQuery = !m_firstMcuStatusQuerySent;
+            } else if (eventCode != static_cast<uint8_t>(PenUsbEventCode::PenRepParam)) {
+                ignoredUnexpectedEvent = true;
+            }
+            break;
+
+        case SessionPhase::AwaitingMcuStatus:
+            if (eventCode == static_cast<uint8_t>(PenUsbEventCode::PenCurStatus)) {
+                m_receivedPenCurStatus = true;
+            } else if (eventCode == static_cast<uint8_t>(PenUsbEventCode::PenTypeInfo)) {
+                m_receivedPenTypeInfo = true;
+            } else if (eventCode != static_cast<uint8_t>(PenUsbEventCode::PenRepParam)) {
+                ignoredUnexpectedEvent = true;
+            }
+
+            if (m_firstMcuStatusQuerySent &&
+                !m_secondMcuStatusQuerySent &&
+                m_receivedPenCurStatus &&
+                m_receivedPenTypeInfo) {
+                sendSecondMcuStatusQuery = true;
+            }
+            break;
+
+        case SessionPhase::AwaitingInitParamRequest:
+            if (eventCode == static_cast<uint8_t>(PenUsbEventCode::PenRepParam)) {
+                if (!m_initParamSent) {
+                    sendInitParams = true;
+                } else {
+                    duplicateInitParamRequest = true;
+                }
+            } else {
+                waitingForInitParamRequest = true;
+            }
+            break;
+
+        case SessionPhase::Running:
+            if (eventCode == static_cast<uint8_t>(PenUsbEventCode::PenRepParam)) {
+                if (m_initParamSent) {
+                    duplicateInitParamRequest = true;
+                } else {
+                    sendInitParams = true;
+                }
+            }
+            break;
+        }
+    }
+
+    if (sendFirstMcuStatusQuery) {
+        LOG_INFO("PenEvent", __func__, "MCU",
+                 "0x71 PEN_CONN_STATUS received while awaiting pen status; issuing first 0x7701 query.");
+        (void)SendFirstMcuStatusQuery();
+        return;
+    }
+
+    if (sendSecondMcuStatusQuery) {
+        LOG_INFO("PenEvent", __func__, "MCU",
+                 "Received expected MCU status pair (0x72 + 0x73); issuing second 0x7701 query.");
+        (void)SendSecondMcuStatusQuery();
+        return;
+    }
+
+    if (sendInitParams) {
+        LOG_INFO("PenEvent", __func__, "MCU",
+                 "0x7B PEN_REP_PARAM received after handshake; sending 0x7D01 InitParam.");
+        (void)SendInitProtocolParams();
+        return;
+    }
+
+    if (duplicateInitParamRequest) {
+        LOG_INFO("PenEvent", __func__, "MCU",
+                 "0x7B PEN_REP_PARAM received → InitParam already sent, skipping.");
+        return;
+    }
+
+    if (waitingForInitParamRequest && phaseAtEvent == SessionPhase::AwaitingInitParamRequest) {
+        LOG_INFO("PenEvent", __func__, "MCU",
+                 "Ignoring event 0x{:02X} while waiting for MCU 0x7B before InitParam.",
+                 eventCode);
+        return;
+    }
+
+    if (ignoredUnexpectedEvent) {
+        LOG_INFO("PenEvent", __func__, "MCU",
+                 "Ignoring event 0x{:02X}; session phase remains {}.",
+                 eventCode, static_cast<int>(phaseAtEvent));
+    }
+}
 
 // ── BtHidChannel hooks ────────────────────────────────────────────────────
 void PenEventBridge::OnConnected() {
-    m_initParamSent = false;  // 允许重连后重新发送 InitParam
+    ResetSessionState();
     RunHandshake();
 }
 
@@ -228,19 +439,8 @@ void PenEventBridge::OnPacketReceived(const std::vector<uint8_t>& packet) {
         SendAck(static_cast<uint8_t>(ackCode));
     }
 
-    // 2. PEN_REP_PARAM (0x7B) → 发送 0x7D01 InitParam (仅第一次)
-    //    Ghidra 验证: USB_AsynchProcThreadProc 的 case 0x7B 只发 ACK(0x0A)。
-    //    InitParam 由 ApDaemon 通过 ServiceInterface[+0xa8] 回调 GetReportInfo(2)
-    //    触发一次。我们在首次收到 0x7B 时发送。
-    if (eventCode == 0x7B && !m_initParamSent) {
-        m_initParamSent = true;
-        SendInitProtocolParams();
-        LOG_INFO("PenEvent", __func__, "MCU",
-                 "0x7B PEN_REP_PARAM received → sent 0x7D01 InitParam (once).");
-    } else if (eventCode == 0x7B) {
-        LOG_INFO("PenEvent", __func__, "MCU",
-                 "0x7B PEN_REP_PARAM received → InitParam already sent, skipping.");
-    }
+    // 2. 使用事件驱动的 session flow 推进握手/InitParam
+    AdvanceSessionFromEvent(eventCode);
 
     // 3. 触发上层回调
     // NOTE: 0x15/0x2E01 handler removed — Ghidra confirms not in factory event table.
@@ -298,72 +498,17 @@ void PenEventBridge::OnPacketReceived(const std::vector<uint8_t>& packet) {
 //   #899 0x7D01 InitProtocolParams (40B = 8 header + 32 payload, USB HID)
 //        发送时间: 握手开始后约 2.8 秒
 void PenEventBridge::RunHandshake() {
-    auto canContinue = [this]() {
-        return IsRunning() && IsTransportOpen();
-    };
-
-    auto sleepInterruptible = [&canContinue](std::chrono::milliseconds total) {
-        constexpr auto kSlice = std::chrono::milliseconds(20);
-        auto slept = std::chrono::milliseconds(0);
-        while (slept < total) {
-            if (!canContinue()) {
-                return false;
-            }
-            const auto remain = total - slept;
-            const auto step = (remain < kSlice) ? remain : kSlice;
-            std::this_thread::sleep_for(step);
-            slept += step;
-        }
-        return canContinue();
-    };
-
-    if (!canContinue()) return;
-    LOG_INFO("PenEvent", __func__, "MCU",
-             "Starting factory init sequence: 0x7101 → 0x7701 → 0x7701 → 0x7D01");
-
-    // Step 1: CheckPenStatus (cmd_id=0x7101)
-    const std::vector<uint8_t> q1 = {0x07,0x00,0x02,0x00, 0x01,0x71, 0x11,0x00};
-    if (!canContinue()) {
-        LOG_INFO("PenEvent", __func__, "MCU", "Handshake aborted before 0x7101 (channel stopped/closed).");
+    if (!IsRunning() || !IsTransportOpen()) {
+        LOG_INFO("PenEvent", __func__, "MCU",
+                 "Handshake skipped because channel is not running/open.");
         return;
     }
-    SendRawPacket(q1);
-    LOG_INFO("PenEvent", __func__, "MCU", "Sent 0x7101 CheckPenStatus");
-
-    if (!sleepInterruptible(std::chrono::milliseconds(300))) {
-        LOG_INFO("PenEvent", __func__, "MCU", "Handshake aborted during stage delay after 0x7101.");
-        return;
-    }
-
-    // Step 2: CheckMcuStatus (cmd_id=0x7701) — 第1次
-    const std::vector<uint8_t> q2 = {0x07,0x00,0x02,0x00, 0x01,0x77, 0x11,0x00};
-    if (!canContinue()) {
-        LOG_INFO("PenEvent", __func__, "MCU", "Handshake aborted before 1st 0x7701 (channel stopped/closed).");
-        return;
-    }
-    SendRawPacket(q2);
-    LOG_INFO("PenEvent", __func__, "MCU", "Sent 0x7701 CheckMcuStatus (1st)");
-
-    // 等待 MCU 处理前两个事件响应 (~20ms in factory trace)
-    if (!sleepInterruptible(std::chrono::milliseconds(500))) {
-        LOG_INFO("PenEvent", __func__, "MCU", "Handshake aborted during stage delay before 2nd 0x7701.");
-        return;
-    }
-
-    // Step 3: CheckMcuStatus (cmd_id=0x7701) — 第2次 (原厂在收到前两个事件 ACK 后重发)
-    if (!canContinue()) {
-        LOG_INFO("PenEvent", __func__, "MCU", "Handshake aborted before 2nd 0x7701 (channel stopped/closed).");
-        return;
-    }
-    SendRawPacket(q2);
-    LOG_INFO("PenEvent", __func__, "MCU", "Sent 0x7701 CheckMcuStatus (2nd)");
-
-    // InitParam (0x7D01) 不在握手阶段发送!
-    // 原厂在收到 MCU 的 0x7B (PEN_REP_PARAM) 事件后才发送 InitParam。
-    // 参见 OnPacketReceived() eventCode==0x7B 处理。
 
     LOG_INFO("PenEvent", __func__, "MCU",
-             "Handshake complete. Waiting for MCU 0x7B event to send InitParam.");
+             "Starting event-driven init sequence: 0x7101 → 0x7701 → 0x7701, with 0x7D01 deferred until MCU 0x7B.");
+    if (!SendQueryPenStatus()) {
+        LOG_WARN("PenEvent", __func__, "MCU", "Failed to start handshake with 0x7101 query.");
+    }
 }
 
 // ── 初始协议参数 ──────────────────────────────────────────────────────────
@@ -373,8 +518,11 @@ void PenEventBridge::RunHandshake() {
 // 被编码为 0x7D01 二进制包发送给 MCU。
 //
 // 我们这里直接用 Type-3 编码器处理这些 hex token。
-void PenEventBridge::SendInitProtocolParams() {
-    if (!IsTransportOpen()) return;
+bool PenEventBridge::SendInitProtocolParams() {
+    if (!IsTransportOpen()) {
+        LOG_WARN("PenEvent", __func__, "MCU", "Transport not open, cannot send 0x7D01 InitProtocolParams.");
+        return false;
+    }
 
     // ── 使用 API Monitor 抓包 (row #1022) 的完整 40 字节报文 ──
     // 原厂 CSV 参数: "3333,3333,2e7,412,258,411a,0f,1,"
@@ -392,9 +540,20 @@ void PenEventBridge::SendInitProtocolParams() {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     };
 
-    SendRawPacket(pkt);
+    if (!SendRawPacket(pkt)) {
+        LOG_WARN("PenEvent", __func__, "MCU", "Failed to send 0x7D01 InitProtocolParams.");
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> sessionLock(m_sessionMutex);
+        m_initParamSent = true;
+        m_sessionPhase = SessionPhase::Running;
+    }
+
     LOG_INFO("PenEvent", __func__, "MCU",
              "0x7D01 InitProtocolParams sent (40B exact factory capture).");
+    return true;
 }
 
 } // namespace Himax::Pen

--- a/EGoTouchService/Device/penevt/PenEventBridge.h
+++ b/EGoTouchService/Device/penevt/PenEventBridge.h
@@ -51,18 +51,38 @@ protected:
     const char* ChannelName() const override { return "PenEventBridge"; }
 
 private:
+    enum class SessionPhase : uint8_t {
+        AwaitingPenStatus = 0,
+        AwaitingMcuStatus,
+        AwaitingInitParamRequest,
+        Running,
+    };
+
     static const GUID kEventDeviceGuid;
     static int GetAckCode(uint8_t eventCode);
 
-    void SendRawPacket(const std::vector<uint8_t>& pkt);
+    bool SendRawPacket(const std::vector<uint8_t>& pkt);
     void SendAck(uint8_t ackCode);
+    void ResetSessionState();
+    void AdvanceSessionFromEvent(uint8_t eventCode);
 
-    void SendInitProtocolParams();
+    bool SendQueryPenStatus();
+    bool SendFirstMcuStatusQuery();
+    bool SendSecondMcuStatusQuery();
+    bool SendInitProtocolParams();
 
     mutable std::mutex m_cbMutex;
+    mutable std::mutex m_sessionMutex;
+    mutable std::mutex m_txMutex;
     PenEventCallback m_eventCallback;
     HANDLE m_notifyEvent = nullptr;
-    bool m_initParamSent = false;  // 原厂只发送一次 InitParam
+    SessionPhase m_sessionPhase = SessionPhase::AwaitingPenStatus;
+    bool m_initParamSent = false;
+    bool m_penStatusQuerySent = false;
+    bool m_firstMcuStatusQuerySent = false;
+    bool m_secondMcuStatusQuerySent = false;
+    bool m_receivedPenCurStatus = false;
+    bool m_receivedPenTypeInfo = false;
 };
 
 } // namespace Himax::Pen

--- a/EGoTouchService/Device/vhf/VhfReporter.cpp
+++ b/EGoTouchService/Device/vhf/VhfReporter.cpp
@@ -5,8 +5,11 @@
 #include <SetupAPI.h>
 
 #include <algorithm>
+#include <array>
+#include <chrono>
 #include <cmath>
-#include <thread>
+#include <span>
+#include <vector>
 
 // ── VHF HID Injector GUID ──
 const GUID VhfReporter::kVhfGuid =
@@ -17,13 +20,55 @@ const GUID VhfReporter::kVhfGuid =
 
 namespace {
 
-static inline void WriteU16Le(std::array<uint8_t, 32>& bytes,
-                              size_t offset, uint16_t value) {
+using TouchPackets = std::array<Solvers::TouchPacket, 2>;
+
+constexpr float kTouchGridHeight = 40.0f;
+constexpr float kTouchGridWidth = 60.0f;
+constexpr float kTouchLogicalMaxY = 16000.0f;
+constexpr float kTouchLogicalMaxX = 25600.0f;
+constexpr size_t kContactsPerPacket = 5;
+constexpr size_t kMaxTouchPackets = 2;
+constexpr size_t kMaxReportedContacts =
+    kContactsPerPacket * kMaxTouchPackets;
+constexpr size_t kTouchPayloadOffset = 1;
+constexpr size_t kTouchContactStride = 6;
+constexpr size_t kTouchContactCountOffset = 31;
+
+class DeviceInfoList {
+public:
+    explicit DeviceInfoList(const GUID& guid)
+        : m_handle(SetupDiGetClassDevsW(
+              &guid, nullptr, nullptr,
+              DIGCF_PRESENT | DIGCF_DEVICEINTERFACE)) {}
+
+    ~DeviceInfoList() {
+        if (m_handle != INVALID_HANDLE_VALUE) {
+            SetupDiDestroyDeviceInfoList(m_handle);
+        }
+    }
+
+    DeviceInfoList(const DeviceInfoList&) = delete;
+    DeviceInfoList& operator=(const DeviceInfoList&) = delete;
+
+    [[nodiscard]] bool IsValid() const {
+        return m_handle != INVALID_HANDLE_VALUE;
+    }
+
+    [[nodiscard]] HDEVINFO Get() const {
+        return m_handle;
+    }
+
+private:
+    HDEVINFO m_handle = INVALID_HANDLE_VALUE;
+};
+
+void WriteU16Le(std::array<uint8_t, 32>& bytes,
+                size_t offset, uint16_t value) {
     bytes[offset] = static_cast<uint8_t>(value & 0xFFu);
     bytes[offset + 1] = static_cast<uint8_t>((value >> 8) & 0xFFu);
 }
 
-static inline uint16_t ToVhf(float gridValue, float gridMax,
+[[nodiscard]] uint16_t ToVhf(float gridValue, float gridMax,
                              float logicalMax, bool invert) {
     const float norm = std::clamp(gridValue / gridMax, 0.0f, 1.0f);
     const int vhf = std::clamp(
@@ -33,58 +78,81 @@ static inline uint16_t ToVhf(float gridValue, float gridMax,
         invert ? (static_cast<int>(logicalMax) - vhf) : vhf);
 }
 
-static inline uint8_t EncodeContactState(const Solvers::TouchContact& c) {
-    if (c.reportEvent == Solvers::TouchReportUp)
+[[nodiscard]] uint8_t EncodeContactState(const Solvers::TouchContact& c) {
+    if (c.reportEvent == Solvers::TouchReportUp) {
         return 0x02; // TipSwitch=0, Confidence=1
+    }
     return 0x03;     // TipSwitch=1, Confidence=1
 }
 
-static void BuildTouchReports(Solvers::HeatmapFrame& frame,
-                              bool transposeEnabled) {
-    for (auto& packet : frame.touchPackets) {
-        packet = Solvers::TouchPacket{};
-        packet.bytes.fill(0);
-        packet.bytes[0] = 0x01;
-    }
-
-    std::vector<const Solvers::TouchContact*> reportable;
-    reportable.reserve(frame.contacts.size());
-    for (const auto& c : frame.contacts) {
-        if (c.id <= 0 || !c.isReported) continue;
-        reportable.push_back(&c);
-    }
-
-    const size_t count = std::min<size_t>(10, reportable.size());
-    frame.touchPackets[0].bytes[31] = static_cast<uint8_t>(count);
-
-    for (size_t i = 0; i < count; ++i) {
-        const auto& c = *reportable[i];
-        const size_t pi = (i < 5) ? 0 : 1;
-        const size_t slot = (i < 5) ? i : (i - 5);
-        const size_t base = 1 + slot * 6;
-        auto& bytes = frame.touchPackets[pi].bytes;
-
-        bytes[base] = EncodeContactState(c);
-        bytes[base + 1] = static_cast<uint8_t>(std::clamp(c.id, 0, 255));
-
-        const bool invertX = !transposeEnabled;
-        const bool invertY = transposeEnabled;
-        WriteU16Le(bytes, base + 2,
-                   ToVhf(c.y, 40.0f, 16000.0f, invertY));
-        WriteU16Le(bytes, base + 4,
-                   ToVhf(c.x, 60.0f, 25600.0f, invertX));
-    }
-
-    frame.touchPackets[0].valid = (count > 0);
-    frame.touchPackets[1].valid = (count > 5);
+[[nodiscard]] bool ShouldReportTouchContact(
+        const Solvers::TouchContact& contact) noexcept {
+    return contact.id > 0 && contact.isReported;
 }
 
-static void ApplyStylusPostTransform(std::array<uint8_t, 17>& bytes,
-                                     uint8_t eraserState) {
-    if (eraserState == 1u)
+[[nodiscard]] bool HasTouchReports(const TouchPackets& packets) noexcept {
+    return packets[0].valid || packets[1].valid;
+}
+
+[[nodiscard]] TouchPackets BuildTouchReports(
+        std::span<const Solvers::TouchContact> contacts,
+        bool transposeEnabled) {
+    TouchPackets packets{};
+    for (auto& packet : packets) {
+        packet.bytes.fill(0);
+        packet.bytes[0] = packet.reportId;
+    }
+
+    const bool invertX = !transposeEnabled;
+    const bool invertY = transposeEnabled;
+    size_t count = 0;
+    for (const auto& contact : contacts) {
+        if (count == kMaxReportedContacts) {
+            break;
+        }
+        if (!ShouldReportTouchContact(contact)) {
+            continue;
+        }
+
+        auto& packet = packets[count / kContactsPerPacket];
+        const size_t slot = count % kContactsPerPacket;
+        const size_t base = kTouchPayloadOffset + slot * kTouchContactStride;
+        auto& bytes = packet.bytes;
+
+        bytes[base] = EncodeContactState(contact);
+        bytes[base + 1] =
+            static_cast<uint8_t>(std::clamp(contact.id, 0, 255));
+        WriteU16Le(bytes, base + 2,
+                   ToVhf(contact.y, kTouchGridHeight,
+                         kTouchLogicalMaxY, invertY));
+        WriteU16Le(bytes, base + 4,
+                   ToVhf(contact.x, kTouchGridWidth,
+                         kTouchLogicalMaxX, invertX));
+        ++count;
+    }
+
+    packets[0].bytes[kTouchContactCountOffset] =
+        static_cast<uint8_t>(count);
+    packets[0].valid = count > 0;
+    packets[1].valid = count > kContactsPerPacket;
+    return packets;
+}
+
+void ApplyStylusPostTransform(std::array<uint8_t, 17>& bytes,
+                              uint8_t eraserState) {
+    if (eraserState == 1u) {
         bytes[1] = static_cast<uint8_t>((bytes[1] & 0xFEu) | 0x0Cu);
-    else
+    } else {
         bytes[1] = static_cast<uint8_t>(bytes[1] & 0xF3u);
+    }
+}
+
+[[nodiscard]] std::array<uint8_t, 17> MakeStylusBytes(
+        const Solvers::StylusPacket& packet,
+        uint8_t eraserState) {
+    auto bytes = packet.bytes;
+    ApplyStylusPostTransform(bytes, eraserState);
+    return bytes;
 }
 
 } // namespace
@@ -96,41 +164,59 @@ VhfReporter::~VhfReporter() { Close(); }
 
 void VhfReporter::Close() {
     std::lock_guard<std::mutex> lk(m_mu);
-    CloseDevice();
+    CloseDeviceLocked();
+    m_nextOpenAttempt = std::chrono::steady_clock::time_point{};
 }
 
 bool VhfReporter::IsDeviceOpen() const {
+    std::lock_guard<std::mutex> lk(m_mu);
     return m_handle != INVALID_HANDLE_VALUE;
+}
+
+bool VhfReporter::UpdateTouchState(bool hasTouch) {
+    if (hasTouch) {
+        m_hadTouchLastFrame.store(true, std::memory_order_relaxed);
+        return false;
+    }
+    return m_hadTouchLastFrame.exchange(false,
+                                         std::memory_order_relaxed);
 }
 
 // ── 主入口 (legacy) ──
 
 void VhfReporter::Dispatch(Solvers::HeatmapFrame& frame) {
-    if (!m_enabled.load()) return;
-
-    BuildTouchReports(frame, m_transpose.load());
-
-    const bool hasTouch =
-        frame.touchPackets[0].valid || frame.touchPackets[1].valid;
-    const bool hasStylus = frame.stylus.packet.valid;
-
-    if (!hasTouch && !hasStylus) {
-        if (m_hadTouchLastFrame.exchange(false)) {
-            std::lock_guard<std::mutex> lk(m_mu);
-            WriteTouchAllUpLocked();
-        }
+    if (!m_enabled.load(std::memory_order_relaxed)) {
         return;
     }
-    m_hadTouchLastFrame.store(true);
+
+    frame.touchPackets = BuildTouchReports(
+        frame.contacts,
+        m_transpose.load(std::memory_order_relaxed));
+
+    const bool hasTouch = HasTouchReports(frame.touchPackets);
+    const bool sendTouchAllUp = UpdateTouchState(hasTouch);
+    const bool hasStylus = frame.stylus.packet.valid;
+
+    if (!hasTouch && !sendTouchAllUp && !hasStylus) {
+        return;
+    }
+
+    std::array<uint8_t, 17> stylusBytes{};
+    if (hasStylus) {
+        stylusBytes = MakeStylusBytes(
+            frame.stylus.packet,
+            m_eraserState.load(std::memory_order_relaxed));
+    }
 
     std::lock_guard<std::mutex> lk(m_mu);
+    if (sendTouchAllUp) {
+        WriteTouchAllUpLocked();
+    }
     if (hasTouch) {
         WriteTouchPacketsLocked(frame.touchPackets);
     }
     if (hasStylus) {
-        ApplyStylusPostTransform(frame.stylus.packet.bytes,
-                                 m_eraserState.load());
-        WriteStylusPacketLocked(frame.stylus.packet.bytes.data(),
+        WriteStylusPacketLocked(stylusBytes.data(),
                                 frame.stylus.packet.length);
     }
 }
@@ -138,11 +224,13 @@ void VhfReporter::Dispatch(Solvers::HeatmapFrame& frame) {
 // ── 独立手写笔写入 ──
 
 void VhfReporter::DispatchStylus(const Solvers::StylusPacket& packet) {
-    if (!m_enabled.load()) return;
-    if (!packet.valid) return;
+    if (!m_enabled.load(std::memory_order_relaxed) || !packet.valid) {
+        return;
+    }
 
-    auto bytes = packet.bytes;
-    ApplyStylusPostTransform(bytes, m_eraserState.load());
+    const auto bytes = MakeStylusBytes(
+        packet,
+        m_eraserState.load(std::memory_order_relaxed));
 
     std::lock_guard<std::mutex> lk(m_mu);
     WriteStylusPacketLocked(bytes.data(), packet.length);
@@ -151,86 +239,111 @@ void VhfReporter::DispatchStylus(const Solvers::StylusPacket& packet) {
 // ── 独立手指写入 ──
 
 void VhfReporter::DispatchTouch(Solvers::HeatmapFrame& frame) {
-    if (!m_enabled.load()) return;
-
-    BuildTouchReports(frame, m_transpose.load());
-
-    const bool hasTouch =
-        frame.touchPackets[0].valid || frame.touchPackets[1].valid;
-
-    if (!hasTouch) {
-        if (m_hadTouchLastFrame.exchange(false)) {
-            std::lock_guard<std::mutex> lk(m_mu);
-            WriteTouchAllUpLocked();
-        }
+    if (!m_enabled.load(std::memory_order_relaxed)) {
         return;
     }
-    m_hadTouchLastFrame.store(true);
+
+    frame.touchPackets = BuildTouchReports(
+        frame.contacts,
+        m_transpose.load(std::memory_order_relaxed));
+
+    const bool hasTouch = HasTouchReports(frame.touchPackets);
+    const bool sendTouchAllUp = UpdateTouchState(hasTouch);
+    if (!hasTouch && !sendTouchAllUp) {
+        return;
+    }
 
     std::lock_guard<std::mutex> lk(m_mu);
-    WriteTouchPacketsLocked(frame.touchPackets);
+    if (sendTouchAllUp) {
+        WriteTouchAllUpLocked();
+    }
+    if (hasTouch) {
+        WriteTouchPacketsLocked(frame.touchPackets);
+    }
 }
 
 // ── 传输写入职责 (requires m_mu held) ──
 
 void VhfReporter::WriteTouchPacketsLocked(
         const std::array<Solvers::TouchPacket, 2>& packets) {
-    if (!EnsureDeviceOpen()) return;
+    if (!EnsureDeviceOpenLocked()) {
+        return;
+    }
 
-    if (packets[0].valid) {
-        WritePacket(packets[0].bytes.data(), packets[0].length, "touch-0");
+    if (packets[0].valid &&
+        !WritePacketLocked(packets[0].bytes.data(),
+                           packets[0].length, "touch-0")) {
+        return;
     }
     if (packets[1].valid) {
-        WritePacket(packets[1].bytes.data(), packets[1].length, "touch-1");
+        WritePacketLocked(packets[1].bytes.data(),
+                          packets[1].length, "touch-1");
     }
 }
 
 void VhfReporter::WriteTouchAllUpLocked() {
-    if (!EnsureDeviceOpen()) return;
+    if (!EnsureDeviceOpenLocked()) {
+        return;
+    }
 
     Solvers::TouchPacket allUp{};
     allUp.bytes.fill(0);
-    allUp.bytes[0] = 0x01;
-    WritePacket(allUp.bytes.data(), allUp.length, "touch-all-up");
+    allUp.bytes[0] = allUp.reportId;
+    WritePacketLocked(allUp.bytes.data(), allUp.length, "touch-all-up");
 }
 
 void VhfReporter::WriteStylusPacketLocked(const uint8_t* data, size_t len) {
-    if (!EnsureDeviceOpen()) return;
-    WritePacket(data, len, "stylus");
+    if (!EnsureDeviceOpenLocked()) {
+        return;
+    }
+    WritePacketLocked(data, len, "stylus");
 }
 
 // ── 设备 I/O ──
 
-bool VhfReporter::EnsureDeviceOpen() {
-    if (m_handle != INVALID_HANDLE_VALUE) return true;
+bool VhfReporter::EnsureDeviceOpenLocked() {
+    if (m_handle != INVALID_HANDLE_VALUE) {
+        return true;
+    }
 
-    HDEVINFO devInfo = SetupDiGetClassDevsW(
-        &kVhfGuid, nullptr, nullptr,
-        DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
-    if (devInfo == INVALID_HANDLE_VALUE) return false;
+    const auto now = std::chrono::steady_clock::now();
+    if (now < m_nextOpenAttempt) {
+        return false;
+    }
 
-    bool opened = false;
+    DeviceInfoList devInfo(kVhfGuid);
+    if (!devInfo.IsValid()) {
+        m_nextOpenAttempt = now + kReopenBackoff;
+        return false;
+    }
+
     for (DWORD idx = 0;; ++idx) {
         SP_DEVICE_INTERFACE_DATA ifData{};
         ifData.cbSize = sizeof(ifData);
         if (!SetupDiEnumDeviceInterfaces(
-                devInfo, nullptr, &kVhfGuid, idx, &ifData)) {
-            if (GetLastError() == ERROR_NO_MORE_ITEMS) break;
+                devInfo.Get(), nullptr, &kVhfGuid, idx, &ifData)) {
+            if (GetLastError() == ERROR_NO_MORE_ITEMS) {
+                break;
+            }
             continue;
         }
+
         DWORD reqSize = 0;
         SetupDiGetDeviceInterfaceDetailW(
-            devInfo, &ifData, nullptr, 0, &reqSize, nullptr);
-        if (reqSize < sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W))
+            devInfo.Get(), &ifData, nullptr, 0, &reqSize, nullptr);
+        if (reqSize < sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W)) {
             continue;
+        }
 
         std::vector<uint8_t> buf(reqSize, 0);
-        auto* detail = reinterpret_cast<
-            SP_DEVICE_INTERFACE_DETAIL_DATA_W*>(buf.data());
+        auto* detail = reinterpret_cast<SP_DEVICE_INTERFACE_DETAIL_DATA_W*>(
+            buf.data());
         detail->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W);
         if (!SetupDiGetDeviceInterfaceDetailW(
-                devInfo, &ifData, detail, reqSize, nullptr, nullptr))
+                devInfo.Get(), &ifData, detail, reqSize,
+                nullptr, nullptr)) {
             continue;
+        }
 
         HANDLE h = CreateFileW(
             detail->DevicePath,
@@ -239,42 +352,45 @@ bool VhfReporter::EnsureDeviceOpen() {
             nullptr, OPEN_EXISTING, 0, nullptr);
         if (h != INVALID_HANDLE_VALUE) {
             m_handle = h;
-            opened = true;
+            m_nextOpenAttempt = std::chrono::steady_clock::time_point{};
             LOG_INFO("VhfReporter", __func__, "VHF", "VHF device opened.");
-            break;
+            return true;
         }
     }
-    SetupDiDestroyDeviceInfoList(devInfo);
-    return opened;
+
+    m_nextOpenAttempt = now + kReopenBackoff;
+    return false;
 }
 
-void VhfReporter::CloseDevice() {
+void VhfReporter::CloseDeviceLocked() {
     if (m_handle != INVALID_HANDLE_VALUE) {
         CloseHandle(m_handle);
         m_handle = INVALID_HANDLE_VALUE;
     }
 }
 
-void VhfReporter::ReopenDevice() {
-    CloseDevice();
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    EnsureDeviceOpen();
+void VhfReporter::ScheduleReopenLocked() {
+    CloseDeviceLocked();
+    m_nextOpenAttempt = std::chrono::steady_clock::now() +
+                        kReopenBackoff;
 }
 
-bool VhfReporter::WritePacket(const uint8_t* data, size_t len,
-                               const char* tag) {
-    if (!data || len == 0) return false;
-    if (!EnsureDeviceOpen()) return false;
-
-    DWORD written = 0;
-    BOOL ok = WriteFile(m_handle, data,
-                        static_cast<DWORD>(len),
-                        &written, nullptr);
-    if (!ok || written != len) {
-        DWORD err = GetLastError();
-        LOG_WARN("VhfReporter", __func__, "VHF", "Write {} failed (len={}, written={}, err={}), trying reopen.", tag, (unsigned)len, (unsigned)written, (unsigned)err);
-        ReopenDevice();
+bool VhfReporter::WritePacketLocked(const uint8_t* data, size_t len,
+                                    const char* tag) {
+    if (!data || len == 0 || m_handle == INVALID_HANDLE_VALUE) {
         return false;
     }
-    return true;
+
+    DWORD written = 0;
+    const BOOL ok = WriteFile(m_handle, data,
+                              static_cast<DWORD>(len),
+                              &written, nullptr);
+    if (ok && written == len) {
+        return true;
+    }
+
+    const DWORD err = ok ? ERROR_WRITE_FAULT : GetLastError();
+    LOG_WARN("VhfReporter", __func__, "VHF", "Write {} failed (len={}, written={}, err={}), scheduling reopen.", tag, (unsigned)len, (unsigned)written, (unsigned)err);
+    ScheduleReopenLocked();
+    return false;
 }

--- a/EGoTouchService/Device/vhf/VhfReporter.h
+++ b/EGoTouchService/Device/vhf/VhfReporter.h
@@ -2,9 +2,10 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <mutex>
-#include <vector>
 
 #include "SolverTypes.h"
 
@@ -32,37 +33,47 @@ public:
     void DispatchTouch(Solvers::HeatmapFrame& frame);
 
     // 开关
-    void SetEnabled(bool v) { m_enabled.store(v); }
-    bool IsEnabled() const { return m_enabled.load(); }
+    void SetEnabled(bool v) { m_enabled.store(v, std::memory_order_relaxed); }
+    bool IsEnabled() const { return m_enabled.load(std::memory_order_relaxed); }
 
-    void SetTransposeEnabled(bool v) { m_transpose.store(v); }
-    bool IsTransposeEnabled() const { return m_transpose.load(); }
+    void SetTransposeEnabled(bool v) {
+        m_transpose.store(v, std::memory_order_relaxed);
+    }
+    bool IsTransposeEnabled() const {
+        return m_transpose.load(std::memory_order_relaxed);
+    }
 
-    void SetEraserState(uint8_t v) { m_eraserState.store(v); }
+    void SetEraserState(uint8_t v) {
+        m_eraserState.store(v, std::memory_order_relaxed);
+    }
 
     bool IsDeviceOpen() const;
     void Close();
 
 private:
+    bool UpdateTouchState(bool hasTouch);
+
     void WriteTouchPacketsLocked(
         const std::array<Solvers::TouchPacket, 2>& packets);
     void WriteTouchAllUpLocked();
     void WriteStylusPacketLocked(const uint8_t* data, size_t len);
 
-    bool EnsureDeviceOpen();
-    void CloseDevice();
-    void ReopenDevice();
-    bool WritePacket(const uint8_t* data, size_t len,
-                     const char* tag);
+    bool EnsureDeviceOpenLocked();
+    void CloseDeviceLocked();
+    void ScheduleReopenLocked();
+    bool WritePacketLocked(const uint8_t* data, size_t len,
+                           const char* tag);
+
+    static constexpr auto kReopenBackoff = std::chrono::milliseconds(200);
 
     std::atomic<bool> m_enabled{true};
     std::atomic<bool> m_transpose{false};
     std::atomic<bool> m_hadTouchLastFrame{false};
     std::atomic<uint8_t> m_eraserState{0};
 
-    std::mutex m_mu;
+    mutable std::mutex m_mu;
     HANDLE m_handle = INVALID_HANDLE_VALUE;
+    std::chrono::steady_clock::time_point m_nextOpenAttempt{};
 
     static const GUID kVhfGuid;
 };
-

--- a/EGoTouchService/Host/SystemStateEvent.h
+++ b/EGoTouchService/Host/SystemStateEvent.h
@@ -6,6 +6,8 @@
 
 namespace Host {
 
+// Authoritative normalized runtime-facing semantics.
+// Transport-level named events may alias to the same normalized event.
 enum class SystemStateEventType : uint8_t {
     Unknown = 0,
     DisplayOn,
@@ -16,6 +18,11 @@ enum class SystemStateEventType : uint8_t {
     ResumeAutomatic,
 };
 
+inline constexpr std::size_t kSystemStateEventTypeCount =
+    static_cast<std::size_t>(SystemStateEventType::ResumeAutomatic) + 1;
+
+// Named events are a transport compatibility surface.
+// Multiple named events may map to the same normalized SystemStateEventType.
 enum class SystemStateNamedEventId : uint8_t {
     MonitorPowerOn = 0,
     MonitorPowerOff,
@@ -28,28 +35,38 @@ enum class SystemStateNamedEventId : uint8_t {
     Count,
 };
 
+enum class SystemStateTransportRole : uint8_t {
+    Canonical = 0,
+    LegacyAlias = 1,
+};
+
 struct SystemStateNamedEventSpec {
     SystemStateNamedEventId id = SystemStateNamedEventId::MonitorPowerOn;
     const wchar_t* name = L"";
     SystemStateEventType type = SystemStateEventType::Unknown;
+    SystemStateTransportRole transportRole = SystemStateTransportRole::Canonical;
 };
 
 inline constexpr size_t kSystemStateNamedEventCount =
     static_cast<size_t>(SystemStateNamedEventId::Count);
 
 inline constexpr SystemStateNamedEventSpec kSystemStateNamedEventSpecs[kSystemStateNamedEventCount] = {
-    {SystemStateNamedEventId::MonitorPowerOn, L"Global\\MonitorPowerOnEvent", SystemStateEventType::DisplayOn},
-    {SystemStateNamedEventId::MonitorPowerOff, L"Global\\MonitorPowerOffEvent", SystemStateEventType::DisplayOff},
-    {SystemStateNamedEventId::MonitorConsoleDisplayOn, L"Global\\MonitorConsoleDisplayOnEvent", SystemStateEventType::DisplayOn},
-    {SystemStateNamedEventId::MonitorConsoleDisplayOff, L"Global\\MonitorConsoleDisplayOffEvent", SystemStateEventType::DisplayOff},
-    {SystemStateNamedEventId::MonitorLidOn, L"Global\\MonitorLidOnEvent", SystemStateEventType::LidOn},
-    {SystemStateNamedEventId::MonitorLidOff, L"Global\\MonitorLidOffEvent", SystemStateEventType::LidOff},
-    {SystemStateNamedEventId::MonitorShutDown, L"Global\\MonitorShutDownEvent", SystemStateEventType::Shutdown},
-    {SystemStateNamedEventId::PbtApmResumeAutomatic, L"Global\\PBT_APMRESUMEAUTOMATIC", SystemStateEventType::ResumeAutomatic},
+    {SystemStateNamedEventId::MonitorPowerOn, L"Global\\MonitorPowerOnEvent", SystemStateEventType::DisplayOn, SystemStateTransportRole::LegacyAlias},
+    {SystemStateNamedEventId::MonitorPowerOff, L"Global\\MonitorPowerOffEvent", SystemStateEventType::DisplayOff, SystemStateTransportRole::LegacyAlias},
+    {SystemStateNamedEventId::MonitorConsoleDisplayOn, L"Global\\MonitorConsoleDisplayOnEvent", SystemStateEventType::DisplayOn, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::MonitorConsoleDisplayOff, L"Global\\MonitorConsoleDisplayOffEvent", SystemStateEventType::DisplayOff, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::MonitorLidOn, L"Global\\MonitorLidOnEvent", SystemStateEventType::LidOn, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::MonitorLidOff, L"Global\\MonitorLidOffEvent", SystemStateEventType::LidOff, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::MonitorShutDown, L"Global\\MonitorShutDownEvent", SystemStateEventType::Shutdown, SystemStateTransportRole::Canonical},
+    {SystemStateNamedEventId::PbtApmResumeAutomatic, L"Global\\PBT_APMRESUMEAUTOMATIC", SystemStateEventType::ResumeAutomatic, SystemStateTransportRole::Canonical},
 };
 
 constexpr size_t ToIndex(SystemStateNamedEventId id) noexcept {
     return static_cast<size_t>(id);
+}
+
+constexpr std::size_t ToIndex(SystemStateEventType type) noexcept {
+    return static_cast<std::size_t>(type);
 }
 
 constexpr const SystemStateNamedEventSpec* TryGetNamedEventSpec(SystemStateNamedEventId id) noexcept {
@@ -67,6 +84,16 @@ constexpr const SystemStateNamedEventSpec* TryGetNamedEventSpec(size_t index) no
     return &kSystemStateNamedEventSpecs[index];
 }
 
+constexpr bool IsCanonicalTransportEvent(SystemStateNamedEventId id) noexcept {
+    const auto* spec = TryGetNamedEventSpec(id);
+    return spec != nullptr && spec->transportRole == SystemStateTransportRole::Canonical;
+}
+
+constexpr bool IsLegacyTransportAlias(SystemStateNamedEventId id) noexcept {
+    const auto* spec = TryGetNamedEventSpec(id);
+    return spec != nullptr && spec->transportRole == SystemStateTransportRole::LegacyAlias;
+}
+
 enum class SystemStateEventSource : uint8_t {
     ThpServiceNamedEvent = 0,
 };
@@ -82,4 +109,3 @@ struct SystemStateEvent {
 const char* ToString(SystemStateEventType type) noexcept;
 
 } // namespace Host
-

--- a/EGoTouchService/Host/SystemStateMonitor.cpp
+++ b/EGoTouchService/Host/SystemStateMonitor.cpp
@@ -21,6 +21,9 @@ struct SystemStateMonitor::Impl {
     EventCallback callback;
     std::thread worker;
     std::atomic<bool> running{false};
+    SystemStateEventType lastDisplayType = SystemStateEventType::Unknown;
+    SystemStateEventType lastLidType = SystemStateEventType::Unknown;
+    bool shutdownObserved = false;
 };
 
 namespace {
@@ -101,6 +104,65 @@ SystemStateMonitor::~SystemStateMonitor() {
 
 namespace {
 
+constexpr std::size_t kInvalidBatchPosition = static_cast<std::size_t>(-1);
+
+const char* ToString(SystemStateTransportRole role) noexcept {
+    switch (role) {
+    case SystemStateTransportRole::Canonical:
+        return "canonical";
+    case SystemStateTransportRole::LegacyAlias:
+        return "legacy_alias";
+    default:
+        return "unknown";
+    }
+}
+
+bool IsDisplayStateEvent(SystemStateEventType type) noexcept {
+    return type == SystemStateEventType::DisplayOn ||
+           type == SystemStateEventType::DisplayOff;
+}
+
+bool IsLidStateEvent(SystemStateEventType type) noexcept {
+    return type == SystemStateEventType::LidOn ||
+           type == SystemStateEventType::LidOff;
+}
+
+template <typename ImplT>
+void ResetNormalizationState(ImplT& impl) noexcept {
+    impl.lastDisplayType = SystemStateEventType::Unknown;
+    impl.lastLidType = SystemStateEventType::Unknown;
+    impl.shutdownObserved = false;
+}
+
+template <typename ImplT>
+bool ShouldSuppressNormalizedEvent(const ImplT& impl, SystemStateEventType type) noexcept {
+    if (IsDisplayStateEvent(type)) {
+        return impl.lastDisplayType == type;
+    }
+    if (IsLidStateEvent(type)) {
+        return impl.lastLidType == type;
+    }
+    if (type == SystemStateEventType::Shutdown) {
+        return impl.shutdownObserved;
+    }
+    return false;
+}
+
+template <typename ImplT>
+void RememberNormalizedEvent(ImplT& impl, SystemStateEventType type) noexcept {
+    if (IsDisplayStateEvent(type)) {
+        impl.lastDisplayType = type;
+        return;
+    }
+    if (IsLidStateEvent(type)) {
+        impl.lastLidType = type;
+        return;
+    }
+    if (type == SystemStateEventType::Shutdown) {
+        impl.shutdownObserved = true;
+    }
+}
+
 SystemStateEvent BuildEvent(std::size_t index) {
     SystemStateEvent event{};
     event.source = SystemStateEventSource::ThpServiceNamedEvent;
@@ -117,6 +179,144 @@ SystemStateEvent BuildEvent(std::size_t index) {
     }
 
     return event;
+}
+
+struct NormalizedBatchEntry {
+    bool present = false;
+    std::size_t firstPosition = kInvalidBatchPosition;
+    SystemStateEvent event{};
+    SystemStateTransportRole transportRole = SystemStateTransportRole::Canonical;
+};
+
+bool ShouldPreferTransportRole(SystemStateTransportRole current, SystemStateTransportRole candidate) noexcept {
+    return current != SystemStateTransportRole::Canonical &&
+           candidate == SystemStateTransportRole::Canonical;
+}
+
+template <typename ImplT>
+std::size_t CollectSignaledEventBatch(
+    ImplT& impl,
+    std::size_t firstEventIndex,
+    std::array<std::size_t, SystemStateMonitor::kEventCount>& batchIndices) noexcept {
+    std::size_t batchCount = 0;
+    batchIndices[batchCount++] = firstEventIndex;
+
+    for (std::size_t i = 0; i < SystemStateMonitor::kEventCount; ++i) {
+        if (i == firstEventIndex) {
+            continue;
+        }
+
+        HANDLE eventHandle = impl.events[i];
+        if (eventHandle == nullptr || eventHandle == INVALID_HANDLE_VALUE) {
+            continue;
+        }
+
+        if (WaitForSingleObject(eventHandle, 0) == WAIT_OBJECT_0) {
+            batchIndices[batchCount++] = i;
+        }
+    }
+
+    return batchCount;
+}
+
+template <typename ImplT>
+void ResetSignaledEvents(
+    ImplT& impl,
+    const std::array<std::size_t, SystemStateMonitor::kEventCount>& batchIndices,
+    std::size_t batchCount) noexcept {
+    for (std::size_t i = 0; i < batchCount; ++i) {
+        HANDLE eventHandle = impl.events[batchIndices[i]];
+        if (eventHandle != nullptr && eventHandle != INVALID_HANDLE_VALUE) {
+            ResetEvent(eventHandle);
+        }
+    }
+}
+
+template <typename ImplT>
+void DispatchNormalizedBatch(
+    ImplT& impl,
+    const std::array<std::size_t, SystemStateMonitor::kEventCount>& batchIndices,
+    std::size_t batchCount) {
+    std::array<NormalizedBatchEntry, kSystemStateEventTypeCount> entries{};
+
+    for (std::size_t position = 0; position < batchCount; ++position) {
+        const std::size_t eventIndex = batchIndices[position];
+        const SystemStateNamedEventSpec* spec = TryGetNamedEventSpec(eventIndex);
+        SystemStateEvent event = BuildEvent(eventIndex);
+        NormalizedBatchEntry& entry = entries[ToIndex(event.type)];
+
+        if (!entry.present) {
+            entry.present = true;
+            entry.firstPosition = position;
+            entry.event = event;
+            if (spec != nullptr) {
+                entry.transportRole = spec->transportRole;
+            }
+            continue;
+        }
+
+        if (spec != nullptr && ShouldPreferTransportRole(entry.transportRole, spec->transportRole)) {
+            const auto firstTimestamp = entry.event.timestamp;
+            entry.event = event;
+            entry.event.timestamp = firstTimestamp;
+            entry.transportRole = spec->transportRole;
+        }
+    }
+
+    for (std::size_t position = 0; position < batchCount; ++position) {
+        const std::size_t eventIndex = batchIndices[position];
+        const SystemStateNamedEventSpec* spec = TryGetNamedEventSpec(eventIndex);
+        const SystemStateEventType type = spec != nullptr ? spec->type : SystemStateEventType::Unknown;
+        const NormalizedBatchEntry& entry = entries[ToIndex(type)];
+
+        if (!entry.present) {
+            continue;
+        }
+
+        if (entry.firstPosition != position) {
+            LOG_INFO(
+                "Host",
+                __func__,
+                "Normalize",
+                "Suppressing named event[{}] as duplicate transport for type={}.",
+                eventIndex,
+                ToString(type));
+            continue;
+        }
+
+        if (ShouldSuppressNormalizedEvent(impl, entry.event.type)) {
+            LOG_INFO(
+                "Host",
+                __func__,
+                "Normalize",
+                "Suppressing normalized duplicate type={} from named event[{}] (role={}).",
+                ToString(entry.event.type),
+                entry.event.raw_index,
+                ToString(entry.transportRole));
+            continue;
+        }
+
+        LOG_INFO(
+            "Host",
+            __func__,
+            "Signal",
+            "Named event[{}] normalized -> type={} (role={}).",
+            entry.event.raw_index,
+            ToString(entry.event.type),
+            ToString(entry.transportRole));
+
+        RememberNormalizedEvent(impl, entry.event.type);
+
+        if (impl.callback) {
+            try {
+                impl.callback(entry.event);
+            } catch (const std::exception& ex) {
+                LOG_ERROR("Host", __func__, "Callback", "SystemStateMonitor callback threw std::exception: {}", ex.what());
+            } catch (...) {
+                LOG_ERROR("Host", __func__, "Callback", "SystemStateMonitor callback threw unknown exception.");
+            }
+        }
+    }
 }
 
 template <typename ImplT>
@@ -169,26 +369,11 @@ void WorkerLoop(ImplT& impl) {
 
         if (wait_result >= WAIT_OBJECT_0 + 1 &&
             wait_result < WAIT_OBJECT_0 + 1 + SystemStateMonitor::kEventCount) {
-            const std::size_t event_index = static_cast<std::size_t>(wait_result - WAIT_OBJECT_0 - 1);
-            SystemStateEvent event = BuildEvent(event_index);
-
-            LOG_INFO("Host", __func__, "Signal", "Named event[{}] signaled → type={}", event_index, ToString(event.type));
-
-            if (impl.callback) {
-                try {
-                    impl.callback(event);
-                } catch (const std::exception& ex) {
-                    LOG_ERROR("Host", __func__, "Callback", "SystemStateMonitor callback threw std::exception: {}", ex.what());
-                } catch (...) {
-                    LOG_ERROR("Host", __func__, "Callback", "SystemStateMonitor callback threw unknown exception.");
-                }
-            }
-
-            HANDLE event_handle = impl.events[event_index];
-            if (event_handle != nullptr && event_handle != INVALID_HANDLE_VALUE) {
-                ResetEvent(event_handle);
-            }
-
+            const std::size_t firstEventIndex = static_cast<std::size_t>(wait_result - WAIT_OBJECT_0 - 1);
+            std::array<std::size_t, SystemStateMonitor::kEventCount> batchIndices{};
+            const std::size_t batchCount = CollectSignaledEventBatch(impl, firstEventIndex, batchIndices);
+            DispatchNormalizedBatch(impl, batchIndices, batchCount);
+            ResetSignaledEvents(impl, batchIndices, batchCount);
             continue;
         }
 
@@ -224,6 +409,7 @@ bool SystemStateMonitor::Start(EventCallback callback) {
         return false;
     }
 
+    ResetNormalizationState(impl);
     impl.callback = std::move(callback);
     impl.stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     if (impl.stopEvent == nullptr) {

--- a/EGoTouchService/Solvers/StylusSolver/AsaTypes.hpp
+++ b/EGoTouchService/Solvers/StylusSolver/AsaTypes.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <array>
 #include <cstdint>
 #include <cstring>
 

--- a/EGoTouchService/Solvers/StylusSolver/FakePressureDecay.hpp
+++ b/EGoTouchService/Solvers/StylusSolver/FakePressureDecay.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <algorithm>
 #include <cstdint>
 
 namespace Asa {

--- a/EGoTouchService/Solvers/StylusSolver/GridPeakDetector.hpp
+++ b/EGoTouchService/Solvers/StylusSolver/GridPeakDetector.hpp
@@ -65,7 +65,7 @@ public:
     // Configuration
     int   noiseThreshold = 50;     // signal > this to be considered (lowered for bringup)
     int   maxConnected   = 81;     // disabled for bringup (full grid = 9*9)
-    int   projRadius     = 2;      // rows/cols around peak for projection
+    int   projRadius     = 1;      // rows/cols around peak for projection
 
 private:
     struct FourNeighborList {

--- a/EGoTouchService/Solvers/StylusSolver/NoPressInkGate.hpp
+++ b/EGoTouchService/Solvers/StylusSolver/NoPressInkGate.hpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <limits>
 
 namespace Asa {
 

--- a/EGoTouchService/Solvers/StylusSolver/PenStateMachine.hpp
+++ b/EGoTouchService/Solvers/StylusSolver/PenStateMachine.hpp
@@ -14,6 +14,10 @@ struct PenFrameEvidence {
     bool sustainActive = false;
     bool activeStylusPresent = false;
     bool hoverSignalPresent = false;
+    bool authoritativeDown = false;
+    bool keepInkAlive = false;
+    bool hoverPresent = false;
+    bool immediateRelease = false;
     bool recheckPassed = true;
     bool overlapLike = false;
     bool edgeLike = false;
@@ -135,13 +139,12 @@ public:
 
         const bool hasCoord = evidence.coordValid;
         const bool hasSignal = !evidence.noSignal && evidence.tx1BlockValid;
-        const bool hasHoverSignal = evidence.hoverSignalPresent || (hasSignal && hasCoord);
-        const uint16_t contactPressure = (evidence.pressureForContact > 0)
-            ? evidence.pressureForContact
-            : evidence.realPressure;
-        const bool contactLike = hasCoord && (contactPressure > 0);
-        const bool activeLike = evidence.activeStylusPresent || contactLike || hasHoverSignal;
-        const bool hoverLike = activeLike && hasCoord && !contactLike;
+        const bool contactLike = evidence.authoritativeDown;
+        const bool activeLike = evidence.keepInkAlive || evidence.hoverPresent ||
+                                evidence.activeStylusPresent || evidence.hoverSignalPresent ||
+                                (hasSignal && hasCoord);
+        const bool hoverLike = evidence.hoverPresent ||
+                               (!contactLike && (evidence.hoverSignalPresent || (hasSignal && hasCoord)));
         const bool noSignalLike = !activeLike || !hasCoord;
 
         if (activeLike && evidence.recheckPassed) {
@@ -178,7 +181,16 @@ public:
             break;
 
         case State::Writing:
-            if (contactLike) {
+            if (evidence.immediateRelease) {
+                m_releaseHoldRemaining = 0;
+                if (hoverLike) {
+                    EnterHover();
+                } else {
+                    EnterNoSignal();
+                }
+                break;
+            }
+            if (evidence.keepInkAlive) {
                 m_releaseHoldRemaining = std::max(1, releaseHoldFrames);
                 ++m_btFrameCount;
                 if (m_branch == Branch::FastDown) {
@@ -191,9 +203,7 @@ public:
                     SetBranch(Branch::None);
                 }
             } else {
-                if (evidence.pressureIsReal && evidence.realMeasuredPressure == 0) {
-                    m_releaseHoldRemaining = 0;
-                } else if (m_releaseHoldRemaining > 0) {
+                if (m_releaseHoldRemaining > 0) {
                     --m_releaseHoldRemaining;
                 }
                 if (hoverLike) {
@@ -205,7 +215,7 @@ public:
             break;
         }
 
-        if (m_state == State::Writing && contactLike) {
+        if (m_state == State::Writing && evidence.keepInkAlive) {
             ++m_totalContactFrames;
         } else if (m_state != State::Writing) {
             m_totalContactFrames = 0;
@@ -497,15 +507,11 @@ private:
             return policy;
 
         case State::Writing:
-            if (evidence.realPressure > 0) {
-                policy.outputPressure = evidence.realPressure;
-            } else if (evidence.mappedPressure > 0 && evidence.recheckPassed && !evidence.overlapLike) {
-                policy.outputPressure = evidence.mappedPressure;
-            }
+            policy.outputPressure = evidence.realPressure;
             break;
         }
 
-        policy.tipSwitchActive = (policy.outputPressure > 0);
+        policy.tipSwitchActive = (m_state == State::Writing);
         policy.noPressInkActive = false;
         policy.sustainOutput = false;
         policy.fastLiftOutput = false;

--- a/EGoTouchService/Solvers/StylusSolver/StylusPipeline.cpp
+++ b/EGoTouchService/Solvers/StylusSolver/StylusPipeline.cpp
@@ -51,6 +51,15 @@ inline bool IsAxisEdgeActive(int32_t coor, int sensorDim) {
     return (coor < margin) || (coor > maxCoor - margin);
 }
 
+inline uint16_t BuildProjectionComposite(const Asa::AsaProjection& proj) {
+    const uint16_t dim1ProjectionPeak =
+        NormalizeProjectionPeak(proj.dim1, proj.peakIdxDim1, proj.spanDim1);
+    const uint16_t dim2ProjectionPeak =
+        NormalizeProjectionPeak(proj.dim2, proj.peakIdxDim2, proj.spanDim2);
+    return ClampU16(
+        (static_cast<int>(dim1ProjectionPeak) + static_cast<int>(dim2ProjectionPeak)) / 2);
+}
+
 inline StylusSignalMetrics BuildSignalMetrics(const Asa::AsaProjection& proj,
                                              const Asa::AsaCoorResult& rawCoor,
                                              uint16_t tx1PeakSignal,
@@ -66,8 +75,7 @@ inline StylusSignalMetrics BuildSignalMetrics(const Asa::AsaProjection& proj,
         NormalizeProjectionPeak(proj.dim1, proj.peakIdxDim1, proj.spanDim1);
     const uint16_t dim2ProjectionPeak =
         NormalizeProjectionPeak(proj.dim2, proj.peakIdxDim2, proj.spanDim2);
-    metrics.tx1Composite = ClampU16(
-        (static_cast<int>(dim1ProjectionPeak) + static_cast<int>(dim2ProjectionPeak)) / 2);
+    metrics.tx1Composite = BuildProjectionComposite(proj);
     metrics.tx2Composite = tx2PeakSignal;
     metrics.dim1EdgeActive = IsAxisEdgeActive(rawCoor.dim1, sensorCols);
     metrics.dim2EdgeActive = IsAxisEdgeActive(rawCoor.dim2, sensorRows);
@@ -141,6 +149,20 @@ bool StylusPipeline::HasCurrentStylusSignal(
              (anchorCol & 0xFFu) == 0x00FFu);
 }
 
+void StylusPipeline::ClosePressureGate(uint32_t latestBtSeq) {
+    m_pressureSolver.Reset();
+    m_pressureGateOpen = false;
+    m_waitingFreshBtAfterRelease = true;
+    m_blockedBtSeqFloor = std::max(m_blockedBtSeqFloor, latestBtSeq);
+}
+
+void StylusPipeline::TrackBlockedBtSeq(uint32_t latestBtSeq) {
+    if (!m_waitingFreshBtAfterRelease) {
+        return;
+    }
+    m_blockedBtSeqFloor = std::max(m_blockedBtSeqFloor, latestBtSeq);
+}
+
 bool StylusPipeline::ProcessNoStylusFrame(
         std::span<const uint8_t> rawData,
         StylusPacket& outPacket) {
@@ -159,7 +181,15 @@ bool StylusPipeline::ProcessNoStylusFrame(
     m_tiltSolver.Reset();
     m_coorReviser.Reset();
     m_linearFilter.Reset();
-    m_pressureSolver.Reset();
+    const auto latestBt = m_btPressBuf.ReadLatest();
+    const bool hadWriting = (m_penStateMachine.GetState() == Asa::PenStateMachine::State::Writing);
+    if (hadWriting) {
+        ClosePressureGate(latestBt.seq);
+    } else {
+        TrackBlockedBtSeq(latestBt.seq);
+        m_pressureSolver.Reset();
+        m_pressureGateOpen = false;
+    }
     m_noPressInkGate.Reset();
     m_noiseGate.Reset();
     m_hasLastGoodFrame = false;
@@ -238,7 +268,14 @@ bool StylusPipeline::ProcessRaw(
     if (!ParseSlaveWords(rawData, sw)) {
         m_lastResult.slaveValid = false;
         m_lastResult.pipelineStage = 1;
-        m_pressureSolver.Reset();
+        const auto latestBt = m_btPressBuf.ReadLatest();
+        if (m_penStateMachine.GetState() == Asa::PenStateMachine::State::Writing) {
+            ClosePressureGate(latestBt.seq);
+        } else {
+            TrackBlockedBtSeq(latestBt.seq);
+            m_pressureSolver.Reset();
+            m_pressureGateOpen = false;
+        }
         m_noPressInkGate.Reset();
         m_postProcessor.Reset();
         m_coorReviser.Reset();
@@ -273,10 +310,17 @@ bool StylusPipeline::ProcessRaw(
     if (!m_gridData.tx1.valid) {
         m_lastResult.point.valid = false;
         m_lastResult.pipelineStage = 2;
+        const auto latestBt = m_btPressBuf.ReadLatest();
         m_postProcessor.Reset();
         m_tiltSolver.Reset();
         m_coorReviser.Reset(); m_linearFilter.Reset();
-        m_pressureSolver.ResetSuppression();
+        if (m_penStateMachine.GetState() == Asa::PenStateMachine::State::Writing) {
+            ClosePressureGate(latestBt.seq);
+        } else {
+            TrackBlockedBtSeq(latestBt.seq);
+            m_pressureSolver.Reset();
+            m_pressureGateOpen = false;
+        }
         m_noiseGate.Reset();
         m_hasLastGoodFrame = false;
         m_prevValid = false;
@@ -292,6 +336,9 @@ bool StylusPipeline::ProcessRaw(
         return false;
     }
 
+    int16_t preCmfTx1Grid[Asa::kGridDim][Asa::kGridDim]{};
+    std::memcpy(preCmfTx1Grid, m_gridData.tx1.grid, sizeof(preCmfTx1Grid));
+
     // 4b. Common-mode filtering
     m_cmfFilter.Apply(m_gridData.tx1.grid);
     if (m_gridData.tx2.valid)
@@ -305,7 +352,12 @@ bool StylusPipeline::ProcessRaw(
     if (!peak.valid) {
         m_lastResult.point.valid = false;
         m_lastResult.pipelineStage = 3;
-        m_pressureSolver.Reset();
+        if (m_penStateMachine.GetState() == Asa::PenStateMachine::State::Writing) {
+            ClosePressureGate(m_btPressBuf.ReadLatest().seq);
+        } else {
+            m_pressureSolver.Reset();
+            m_pressureGateOpen = false;
+        }
         m_noPressInkGate.Reset();
         m_prevValid = false;
                 Asa::PenFrameEvidence evidence{};
@@ -333,7 +385,12 @@ bool StylusPipeline::ProcessRaw(
     if (!rawCoor.valid) {
         m_lastResult.point.valid = false;
         m_lastResult.pipelineStage = 4;
-        m_pressureSolver.Reset();
+        if (m_penStateMachine.GetState() == Asa::PenStateMachine::State::Writing) {
+            ClosePressureGate(m_btPressBuf.ReadLatest().seq);
+        } else {
+            m_pressureSolver.Reset();
+            m_pressureGateOpen = false;
+        }
         m_noPressInkGate.Reset();
         m_prevValid = false;
                 Asa::PenFrameEvidence evidence{};
@@ -371,7 +428,12 @@ bool StylusPipeline::ProcessRaw(
     if (m_noiseGate.DetectNoiseJump(rawCoor)) {
         m_lastResult.point.valid = false;
         m_lastResult.pipelineStage = 5;
-        m_pressureSolver.Reset();
+        if (m_penStateMachine.GetState() == Asa::PenStateMachine::State::Writing) {
+            ClosePressureGate(m_btPressBuf.ReadLatest().seq);
+        } else {
+            m_pressureSolver.Reset();
+            m_pressureGateOpen = false;
+        }
         m_noPressInkGate.Reset();
         m_prevValid = false;
         m_postProcessor.Reset();
@@ -391,9 +453,6 @@ bool StylusPipeline::ProcessRaw(
 
     // ── Phase 2.5: Pressure + State Machine → MotionProfile ──
 
-    const bool wasInking = m_lastResult.tipSwitchActive ||
-                           (m_hasLastGoodFrame && m_lastGoodFrame.tipSwitchActive);
-
     const uint16_t tx1PeakSignal = static_cast<uint16_t>(
         std::clamp(m_gridData.tx1.grid[peak.peakRow][peak.peakCol],
                    static_cast<int16_t>(0), static_cast<int16_t>(0x7FFF)));
@@ -411,9 +470,17 @@ bool StylusPipeline::ProcessRaw(
         }
     }
 
+    const auto preCmfTx1Projection = m_peakDetector.ProjectTo1D(preCmfTx1Grid, peak);
+
     // Pressure (BT MCU) — solve BEFORE state machine
-    const auto metrics = BuildSignalMetrics(
-        proj, rawCoor, tx1PeakSignal, tx2PeakSignal, m_sensorCols, m_sensorRows);
+    auto metrics = BuildSignalMetrics(
+        proj,
+        rawCoor,
+        tx1PeakSignal,
+        tx2PeakSignal,
+        m_sensorCols,
+        m_sensorRows);
+    metrics.tx1Composite = BuildProjectionComposite(preCmfTx1Projection);
     const bool isEdge = metrics.dim1EdgeActive || metrics.dim2EdgeActive;
     m_lastResult.tx1BlockValid = m_gridData.tx1.valid;
     m_lastResult.tx2BlockValid = m_gridData.tx2.valid;
@@ -426,6 +493,55 @@ bool StylusPipeline::ProcessRaw(
     m_lastResult.hpp3Dim2SignalValid = (m_lastResult.signalY > 0);
     const auto btSample = m_btPressBuf.ReadLatest();
     m_lastResult.point.rawPressure = btSample.pressure;
+
+    const bool previouslyWriting =
+        (m_penStateMachine.GetState() == Asa::PenStateMachine::State::Writing);
+    const auto recheck = BuildRecheckContext(
+        metrics, rawCoor.valid, previouslyWriting, m_recheckThBase, m_recheckThMulti);
+    const bool recheckPassed = m_noiseGate.EvaluateRecheck(
+        metrics.signalX, metrics.signalY, metrics.maxRawPeak,
+        recheck.finalThreshold, recheck.sustainThreshold, recheck.overlapLike);
+    const bool baseValid = rawCoor.valid && m_lastResult.tx1BlockValid && recheckPassed;
+    const bool hoverPresent = baseValid &&
+                              (metrics.tx1Composite >= m_tx1LiftAbsoluteThreshold);
+    const bool authoritativeDown = baseValid &&
+                                   (metrics.tx1Composite >= m_tx1InkEnterThreshold);
+    const bool keepInkAlive = baseValid &&
+                              (metrics.tx1Composite >= m_tx1LiftSuspiciousThreshold);
+    const bool suspiciousDrop = previouslyWriting && baseValid &&
+                                (metrics.tx1Composite >= m_tx1LiftAbsoluteThreshold) &&
+                                (metrics.tx1Composite < m_tx1LiftSuspiciousThreshold);
+    const bool immediateRelease = previouslyWriting && !suspiciousDrop &&
+                                  (!baseValid ||
+                                   (metrics.tx1Composite < m_tx1LiftAbsoluteThreshold));
+
+    if (suspiciousDrop && m_hasLastGoodFrame) {
+        TrackBlockedBtSeq(btSample.seq);
+        m_lastResult = m_lastGoodFrame;
+        outPacket = m_lastGoodFrame.packet;
+        m_prevStatus = m_lastResult.status;
+        return outPacket.valid;
+    }
+
+    if (!authoritativeDown) {
+        TrackBlockedBtSeq(btSample.seq);
+    }
+    if (immediateRelease) {
+        ClosePressureGate(btSample.seq);
+    }
+
+    if (authoritativeDown && !m_pressureGateOpen) {
+        if (m_waitingFreshBtAfterRelease) {
+            if (btSample.hasSample && btSample.seq > m_blockedBtSeqFloor) {
+                m_pressureGateOpen = true;
+                m_waitingFreshBtAfterRelease = false;
+                m_blockedBtSeqFloor = btSample.seq;
+            }
+        } else {
+            m_pressureGateOpen = btSample.hasSample;
+        }
+    }
+
     const Asa::EdgeSignalInputs edgeSignals{
         metrics.dim1EdgeActive,
         metrics.dim2EdgeActive,
@@ -433,26 +549,21 @@ bool StylusPipeline::ProcessRaw(
         static_cast<int>(metrics.dim2EdgeSignal)
     };
     const auto pressureStage = m_pressureSolver.SolveStage(
-        btSample, rawCoor.valid,
+        btSample, m_pressureGateOpen,
         static_cast<int>(metrics.signalX),
         isEdge, edgeSignals);
-
-    const bool recentlyWriting = m_hasLastGoodFrame && m_lastGoodFrame.tipSwitchActive;
-    const auto recheck = BuildRecheckContext(
-        metrics, rawCoor.valid, recentlyWriting, m_recheckThBase, m_recheckThMulti);
-    const bool recheckPassed = m_noiseGate.EvaluateRecheck(
-        metrics.signalX, metrics.signalY, metrics.maxRawPeak,
-        recheck.finalThreshold, recheck.sustainThreshold, recheck.overlapLike);
 
     Asa::PenFrameEvidence evidence{};
     evidence.coordValid = rawCoor.valid;
     evidence.noSignal = false;
     evidence.tx1BlockValid = m_lastResult.tx1BlockValid;
     evidence.sustainActive = false;
-    evidence.activeStylusPresent = rawCoor.valid && m_lastResult.tx1BlockValid &&
-                                   (metrics.tx1Composite >= recheck.finalThreshold);
-    evidence.hoverSignalPresent = rawCoor.valid && m_lastResult.tx1BlockValid &&
-                                  metrics.tx1Composite >= recheck.finalThreshold;
+    evidence.activeStylusPresent = hoverPresent;
+    evidence.hoverSignalPresent = hoverPresent;
+    evidence.authoritativeDown = authoritativeDown;
+    evidence.keepInkAlive = keepInkAlive;
+    evidence.hoverPresent = hoverPresent && !keepInkAlive;
+    evidence.immediateRelease = immediateRelease;
     evidence.recheckPassed = recheckPassed;
     evidence.overlapLike = recheck.overlapLike;
     evidence.edgeLike = isEdge;
@@ -473,6 +584,14 @@ bool StylusPipeline::ProcessRaw(
     const auto& motion = update.motion;
     const auto& output = update.output;
 
+    if (m_penStateMachine.JustLeftRange()) {
+        ClosePressureGate(btSample.seq);
+        m_postProcessor.Reset();
+        m_linearFilter.Reset();
+        m_coorReviser.Reset();
+        m_noiseGate.Reset();
+    }
+
     m_lastResult.point.mappedPressure = pressureStage.mappedPressure;
     m_lastResult.pressure = output.outputPressure;
     m_lastResult.point.pressure = m_lastResult.pressure;
@@ -490,14 +609,6 @@ bool StylusPipeline::ProcessRaw(
 #endif
 
     m_lastResult.animState = m_penStateMachine.GetAnimState();
-
-    // Handle pen-leave resets
-    if (m_penStateMachine.JustLeftRange()) {
-        m_postProcessor.Reset();
-        m_linearFilter.Reset();
-        m_coorReviser.Reset();
-        m_noiseGate.Reset();
-    }
 
     // ── Phase 3: Post-Processing Chain (all in GLOBAL space, Profile-driven) ──
 
@@ -703,6 +814,12 @@ std::vector<ConfigParam> StylusPipeline::GetConfigSchema() const {
             ConfigParam::Int, const_cast<int*>(&m_recheckThBase), 10, 5000, Cat::Solver),
         ConfigParam("sp.recheckThMulti", "Signal Thresh Multi",
             ConfigParam::Int, const_cast<int*>(&m_recheckThMulti), 10, 5000, Cat::Solver),
+        ConfigParam("sp.tx1InkEnterTh", "TX1 Ink Enter Threshold",
+            ConfigParam::Int, const_cast<int*>(&m_tx1InkEnterThreshold), 10, 30000, Cat::Solver),
+        ConfigParam("sp.tx1LiftSuspiciousTh", "TX1 Lift Suspicious Threshold",
+            ConfigParam::Int, const_cast<int*>(&m_tx1LiftSuspiciousThreshold), 10, 30000, Cat::Solver),
+        ConfigParam("sp.tx1LiftAbsoluteTh", "TX1 Lift Absolute Threshold",
+            ConfigParam::Int, const_cast<int*>(&m_tx1LiftAbsoluteThreshold), 10, 30000, Cat::Solver),
         ConfigParam("sp.pitchMapEnabled", "Pitch Map Enabled",
             ConfigParam::Bool, const_cast<bool*>(&m_pitchMapEnabled), Cat::Solver),
         ConfigParam("sp.tpPatternEnabled", "TP Pattern Comp Enabled",
@@ -880,6 +997,9 @@ void StylusPipeline::SaveConfig(std::ostream& out) const {
     out << "sp.recheckEnabled=" << m_noiseGate.recheckEnabled << "\n";
     out << "sp.recheckThBase=" << m_recheckThBase << "\n";
     out << "sp.recheckThMulti=" << m_recheckThMulti << "\n";
+    out << "sp.tx1InkEnterTh=" << m_tx1InkEnterThreshold << "\n";
+    out << "sp.tx1LiftSuspiciousTh=" << m_tx1LiftSuspiciousThreshold << "\n";
+    out << "sp.tx1LiftAbsoluteTh=" << m_tx1LiftAbsoluteThreshold << "\n";
     out << "sp.cmfEnabled=" << m_cmfFilter.enabled << "\n";
     out << "sp.cmfWindowSize=" << m_cmfFilter.windowSize << "\n";
     out << "sp.tpPatternEnabled=" << m_tpPatternCompEnabled << "\n";
@@ -970,6 +1090,9 @@ void StylusPipeline::LoadConfig(
     else if (key == "sp.recheckEnabled") m_noiseGate.recheckEnabled = toBool(value);
     else if (key == "sp.recheckThBase") m_recheckThBase = toInt(value);
     else if (key == "sp.recheckThMulti") m_recheckThMulti = toInt(value);
+    else if (key == "sp.tx1InkEnterTh") m_tx1InkEnterThreshold = toInt(value);
+    else if (key == "sp.tx1LiftSuspiciousTh") m_tx1LiftSuspiciousThreshold = toInt(value);
+    else if (key == "sp.tx1LiftAbsoluteTh") m_tx1LiftAbsoluteThreshold = toInt(value);
     else if (key == "sp.cmfEnabled") m_cmfFilter.enabled = toBool(value);
     else if (key == "sp.cmfWindowSize") m_cmfFilter.windowSize = toInt(value);
     else if (key == "sp.tpPatternEnabled") m_tpPatternCompEnabled = toBool(value);

--- a/EGoTouchService/Solvers/StylusSolver/StylusPipeline.h
+++ b/EGoTouchService/Solvers/StylusSolver/StylusPipeline.h
@@ -88,6 +88,8 @@ private:
     bool HasCurrentStylusSignal(std::span<const uint8_t> rawData) const;
     bool ProcessNoStylusFrame(std::span<const uint8_t> rawData,
                               StylusPacket& outPacket);
+    void ClosePressureGate(uint32_t latestBtSeq);
+    void TrackBlockedBtSeq(uint32_t latestBtSeq);
 
     // ── Algorithm modules (header-only) ──
     Asa::GridPeakDetector    m_peakDetector;
@@ -116,6 +118,9 @@ private:
     uint32_t m_prevStatus = 0;
     float m_prevPointX = 0.0f;
     float m_prevPointY = 0.0f;
+    bool m_pressureGateOpen = false;
+    bool m_waitingFreshBtAfterRelease = false;
+    uint32_t m_blockedBtSeqFloor = 0;
 
     // ── Sensor dimensions ──
     int m_sensorRows = 40;
@@ -144,6 +149,9 @@ private:
     bool m_enableSlaveChecksum = false;
     bool m_emitPacketWhenInvalid = true;
     int  m_btMapMode = 0;
+    int  m_tx1InkEnterThreshold = 9000;
+    int  m_tx1LiftSuspiciousThreshold = 7000;
+    int  m_tx1LiftAbsoluteThreshold = 4500;
 
     // P3 #16: TP Pattern Compensation (placeholder)
     bool m_tpPatternCompEnabled = false;

--- a/EGoTouchService/Solvers/TouchSolver/BaselineSubtraction.hpp
+++ b/EGoTouchService/Solvers/TouchSolver/BaselineSubtraction.hpp
@@ -3,7 +3,6 @@
 // Header-only. Converted from Preprocessing/BaselineSubtraction.{h,cpp}.
 
 #include "SolverTypes.h"
-#include "NeonCompat.h"
 #include <cstddef>
 #include <cstdint>
 

--- a/EGoTouchService/Solvers/TouchSolver/CMFProcessor.hpp
+++ b/EGoTouchService/Solvers/TouchSolver/CMFProcessor.hpp
@@ -4,7 +4,6 @@
 // Common Mode Filter: removes global row/column shift noise.
 
 #include "SolverTypes.h"
-#include "NeonCompat.h"
 #include <algorithm>
 #include <cstdint>
 

--- a/EGoTouchService/Solvers/TouchSolver/EdgeRejection.hpp
+++ b/EGoTouchService/Solvers/TouchSolver/EdgeRejection.hpp
@@ -6,7 +6,6 @@
 #include "SolverTypes.h"
 #include "EdgeCompensation.h"
 #include <vector>
-#include <cstdint>
 
 namespace Solvers { namespace Touch {
 

--- a/EGoTouchService/Solvers/TouchSolver/GridIIRProcessor.hpp
+++ b/EGoTouchService/Solvers/TouchSolver/GridIIRProcessor.hpp
@@ -4,7 +4,6 @@
 // Dynamic threshold gated IIR with aggressive noise floor decay.
 
 #include "SolverTypes.h"
-#include "NeonCompat.h"
 #include <algorithm>
 #include <cstring>
 #include <cmath>

--- a/EGoTouchService/Solvers/TouchSolver/MasterFrameParser.hpp
+++ b/EGoTouchService/Solvers/TouchSolver/MasterFrameParser.hpp
@@ -5,7 +5,6 @@
 
 #include "SolverTypes.h"
 #include "FrameLayout.h"
-#include <cstring>
 
 namespace Solvers { namespace Touch {
 

--- a/EGoTouchService/Solvers/TouchSolver/PalmRejector.hpp
+++ b/EGoTouchService/Solvers/TouchSolver/PalmRejector.hpp
@@ -6,7 +6,6 @@
 #include "SolverTypes.h"
 #include <vector>
 #include <algorithm>
-#include <cstdint>
 
 namespace Solvers { namespace Touch {
 

--- a/EGoTouchService/Solvers/TouchSolver/TouchGestureStateMachine.hpp
+++ b/EGoTouchService/Solvers/TouchSolver/TouchGestureStateMachine.hpp
@@ -6,8 +6,6 @@
 #include "SolverTypes.h"
 #include <array>
 #include <cstdint>
-#include <algorithm>
-#include <cmath>
 
 namespace Solvers { namespace Touch {
 

--- a/EGoTouchService/Solvers/TouchSolver/TouchPipeline.cpp
+++ b/EGoTouchService/Solvers/TouchSolver/TouchPipeline.cpp
@@ -1,5 +1,4 @@
 #include "TouchPipeline.h"
-#include "Logger.h"
 
 namespace Solvers {
 

--- a/EGoTouchService/include/ServiceShell.h
+++ b/EGoTouchService/include/ServiceShell.h
@@ -38,7 +38,9 @@ private:
     static DWORD WINAPI SvcCtrlHandlerEx(
         DWORD ctrl, DWORD evtType,
         LPVOID evtData, LPVOID ctx);
+    static BOOL WINAPI ConsoleCtrlHandler(DWORD ctrlType);
 
+    void SignalShutdownTransportAndStop() noexcept;
     void RegisterPowerNotifications();
     void UnregisterPowerNotifications();
     void ReportStatus(DWORD state, DWORD waitHint = 0);

--- a/EGoTouchService/source/ServiceShell.cpp
+++ b/EGoTouchService/source/ServiceShell.cpp
@@ -77,9 +77,8 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
     case SERVICE_CONTROL_SHUTDOWN:
     case SERVICE_CONTROL_PRESHUTDOWN:
         LOG_INFO("Service", __func__, "Stopping", "Received stop/shutdown control code={}.", ctrl);
-        signalEvent(Host::SystemStateNamedEventId::MonitorShutDown);
+        s->SignalShutdownTransportAndStop();
         s->ReportStatus(SERVICE_STOP_PENDING, 5000);
-        SetEvent(s->m_impl->stopEvent);
         return NO_ERROR;
 
     case SERVICE_CONTROL_POWEREVENT: {
@@ -135,13 +134,31 @@ DWORD WINAPI ServiceShell::SvcCtrlHandlerEx(
 
 // ─── 控制台模式 ──────────────────────────────
 
+BOOL WINAPI ServiceShell::ConsoleCtrlHandler(DWORD ctrlType) {
+    switch (ctrlType) {
+    case CTRL_C_EVENT:
+    case CTRL_BREAK_EVENT:
+    case CTRL_CLOSE_EVENT:
+    case CTRL_LOGOFF_EVENT:
+    case CTRL_SHUTDOWN_EVENT:
+        Instance()->SignalShutdownTransportAndStop();
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+void ServiceShell::SignalShutdownTransportAndStop() noexcept {
+    Host::SystemStateMonitor::SignalNamedEvent(Host::SystemStateNamedEventId::MonitorShutDown);
+    if (m_impl != nullptr && m_impl->stopEvent != nullptr) {
+        SetEvent(m_impl->stopEvent);
+    }
+}
+
 void ServiceShell::RunAsConsole() {
     m_impl->stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    SetConsoleCtrlHandler([](DWORD) -> BOOL {
-        SetEvent(Instance()->m_impl->stopEvent);
-        return TRUE;
-    }, TRUE);
+    SetConsoleCtrlHandler(&ServiceShell::ConsoleCtrlHandler, TRUE);
 
     LOG_INFO("Service", __func__, "Boot", "Starting modules (console mode)...");
     if (!m_impl->host.Start()) {

--- a/Tools/tests/StylusPipelineFastInkTest.cpp
+++ b/Tools/tests/StylusPipelineFastInkTest.cpp
@@ -323,19 +323,16 @@ void TestStylusPipelineNoPressSyntheticPressure() {
     Require(!f1.fastLiftOutput, "fast-lift output should remain disabled");
 }
 
-void TestStylusPipelineLowSignalPressureSuppress() {
+void TestStylusPipelineLowSignalKeepsCoordinateButZeroPressureUntilAuthoritativeDown() {
     StylusPipeline pipeline;
-    pipeline.LoadConfig("sp.sigSuppressEnabled", "1");
-    pipeline.LoadConfig("sp.sigSuppressEnter", "2200");
-    pipeline.LoadConfig("sp.sigSuppressExit", "3200");
-    pipeline.LoadConfig("sp.noPressEnabled", "0");
 
     const auto weakGrid = MakeCrossGrid(1800, 1400, 900, 600);
     const auto raw = BuildCombinedStylusFrame(12, 12, weakGrid, 12, 12, {});
 
     const auto frame = RunFrame(pipeline, raw, 180, 8);
     Require(frame.point.valid, "weak-signal frame should still solve coordinates");
-    Require(frame.pressure > 0, "weak-signal frame should no longer suppress pressure");
+    Require(frame.pressure == 0, "weak-signal frame should not output pressure before authoritative down");
+    Require(!frame.tipSwitchActive, "weak-signal frame should remain out of writing state");
     Require(!frame.noPressInkActive, "no-press ink should stay inactive");
 }
 
@@ -358,6 +355,7 @@ void TestStylusPipelineFastLiftToNoSignal() {
     const auto lift = RunFrame(pipeline, BuildCombinedStylusFrame(0x00FF, 0x00FF, {}, 0, 0, {}), 0, 16);
     Require(!lift.point.valid, "no-signal lift frame should not keep a valid point");
     Require(lift.pressure == 0, "no-signal lift frame should drop pressure");
+    Require(!lift.tipSwitchActive, "no-signal lift frame should clear tip switch");
     Require(!lift.noPressInkActive, "no-signal lift frame should keep no-press inactive");
 }
 
@@ -366,17 +364,23 @@ void TestStylusPipelineReleaseRetainsPreviousOutput() {
     pipeline.LoadConfig("sp.noPressEnabled", "0");
     pipeline.LoadConfig("sp.sigSuppressEnabled", "0");
     pipeline.LoadConfig("sp.filterMode", "2");
+    pipeline.LoadConfig("sp.tx1InkEnterTh", "9000");
+    pipeline.LoadConfig("sp.tx1LiftSuspiciousTh", "7000");
+    pipeline.LoadConfig("sp.tx1LiftAbsoluteTh", "4500");
 
     const auto raw = BuildCombinedStylusFrame(10, 10,
         MakeCrossGrid(12000, 9000, 7000, 5000, 4, 4), 10, 10, {});
+    const auto suspiciousRaw = BuildCombinedStylusFrame(10, 10,
+        MakeCrossGrid(6500, 6500, 6400, 6300, 4, 4), 10, 10, {});
     const auto down = RunFrame(pipeline, raw, 220, 8);
     Require(down.point.valid, "precondition should produce a valid down frame");
     Require(down.pressure > 0, "precondition should carry pressure");
 
-    const auto weak = RunFrame(pipeline, raw, 0, 16);
+    const auto weak = RunFrame(pipeline, suspiciousRaw, 0, 16);
     Require(!weak.fastLiftOutput, "fast-lift output should stay disabled");
     Require(!weak.sustainOutput, "sustain output should stay disabled");
-    Require(weak.pressure == 0, "zero BT pressure should not retain synthetic output");
+    Require(weak.pressure == down.pressure, "suspicious frame should reuse previous committed pressure");
+    Require(weak.tipSwitchActive == down.tipSwitchActive, "suspicious frame should reuse previous tip state");
 }
 
 void TestStylusPipelineEdgeFastLiftRetainsCoordinate() {
@@ -399,6 +403,9 @@ void TestStylusPipelineConfigRoundTrip() {
     StylusPipeline pipeline;
     pipeline.LoadConfig("sp.recheckThBase", "888");
     pipeline.LoadConfig("sp.recheckThMulti", "1333");
+    pipeline.LoadConfig("sp.tx1InkEnterTh", "9000");
+    pipeline.LoadConfig("sp.tx1LiftSuspiciousTh", "7000");
+    pipeline.LoadConfig("sp.tx1LiftAbsoluteTh", "4500");
     pipeline.LoadConfig("sp.edgeSigSuppressEnabled", "1");
     pipeline.LoadConfig("sp.edgeSigSuppressEnter", "1444");
     pipeline.LoadConfig("sp.edgeSigSuppressExit", "3555");
@@ -426,6 +433,12 @@ void TestStylusPipelineConfigRoundTrip() {
             "saved config should include recheck base threshold");
     Require(saved.find("sp.recheckThMulti=1333") != std::string::npos,
             "saved config should include recheck multi threshold");
+    Require(saved.find("sp.tx1InkEnterTh=9000") != std::string::npos,
+            "saved config should include tx1 ink enter threshold");
+    Require(saved.find("sp.tx1LiftSuspiciousTh=7000") != std::string::npos,
+            "saved config should include tx1 suspicious lift threshold");
+    Require(saved.find("sp.tx1LiftAbsoluteTh=4500") != std::string::npos,
+            "saved config should include tx1 absolute lift threshold");
     Require(saved.find("sp.edgeSigSuppressEnter=") == std::string::npos,
             "saved config should not include deprecated edge suppress keys");
     Require(saved.find("sp.noPressBaseTh=") == std::string::npos,
@@ -466,6 +479,9 @@ void TestStylusPipelineConfigRoundTrip() {
     Require(!hasKey("sp.btMapMode"), "schema should not expose deprecated bt map mode key");
     Require(!hasKey("sp.pressIirQ8"), "schema should not expose deprecated pressure iir key");
     Require(hasKey("sp.recheckThMulti"), "schema should expose recheck multi threshold");
+    Require(hasKey("sp.tx1InkEnterTh"), "schema should expose tx1 ink enter threshold");
+    Require(hasKey("sp.tx1LiftSuspiciousTh"), "schema should expose tx1 suspicious lift threshold");
+    Require(hasKey("sp.tx1LiftAbsoluteTh"), "schema should expose tx1 absolute lift threshold");
 }
 
 void TestGridPeakDetectorNoPeak() {
@@ -494,8 +510,8 @@ void TestGridPeakDetectorCenterPeakAndProjection() {
             "center cross should peak at the center cell");
     Require(analysis.projection.peakIdxDim1 == 4 && analysis.projection.peakIdxDim2 == 4,
             "center cross projection should peak on the center axis");
-    Require(analysis.projection.spanDim1 == 5 && analysis.projection.spanDim2 == 5,
-            "default projection radius should span five rows and columns");
+    Require(analysis.projection.spanDim1 == 3 && analysis.projection.spanDim2 == 3,
+            "default projection radius should span three rows and columns");
 }
 
 void TestGridPeakDetectorEdgePeak() {
@@ -589,7 +605,7 @@ void TestStylusPipelinePeakMetrics() {
     Require(frame.point.valid, "pipeline should still solve a valid stylus point");
     Require(frame.signalX == 16000, "TX1 peak signal should match the detector peak");
     Require(frame.signalY == 6000, "TX2 peak signal should match the detector peak");
-    Require(frame.point.peakTx1 == 12800, "TX1 composite peak should match the projection average");
+    Require(frame.point.peakTx1 == 14666, "TX1 composite peak should use the pre-CMF projection average");
     Require(frame.point.peakTx2 == 6000, "TX2 composite peak should mirror TX2 peak signal");
 }
 
@@ -617,15 +633,23 @@ void TestStylusPipelineUsesPredictedIntermediatePressure() {
     Require(f1.diag.predictedAgeFrames >= 1, "predicted frame should increase predicted age");
 #endif
 
-    const auto f2 = RunFrame(pipeline, raw, 260, 24, true);
-    Require(f2.pressure > 0, "next real BT frame should still output pressure");
+    const auto lift = RunFrame(pipeline, BuildCombinedStylusFrame(0x00FF, 0x00FF, {}, 0, 0, {}), 220, 20, false);
+    Require(lift.pressure == 0, "release should close pressure gate immediately");
+    Require(!lift.tipSwitchActive, "release should clear tip switch");
+
+    const auto hoverOnly = RunFrame(pipeline, raw, 220, 24, false);
+    Require(hoverOnly.tipSwitchActive, "TX1 should still allow immediate writing on the next down frame");
+    Require(hoverOnly.pressure == 0, "stale BT sample should not reopen pressure gate");
+
+    const auto f2 = RunFrame(pipeline, raw, 260, 32, true);
+    Require(f2.pressure > 0, "new BT push after release should reopen pressure output");
 #if EGOTOUCH_DIAG
     Require(f2.diag.pressureIsReal, "new BT push should restore real pressure flag");
-    Require(f2.diag.btSeq == 2, "second BT push should advance sequence");
+    Require(f2.diag.btSeq >= 2, "new BT push should advance sequence");
 #endif
 }
 
-void TestStylusPipelineRealZeroReleasesQuickly() {
+void TestStylusPipelineRealZeroDropsPressureButKeepsWritingWhenTx1StillDown() {
     StylusPipeline pipeline;
     pipeline.LoadConfig("sp.filterMode", "2");
 
@@ -637,7 +661,7 @@ void TestStylusPipelineRealZeroReleasesQuickly() {
 
     const auto up = RunFrame(pipeline, raw, 0, 16, true);
     Require(up.pressure == 0, "real zero BT sample should drop output pressure immediately");
-    Require(!up.tipSwitchActive, "real zero BT sample should clear tip switch quickly");
+    Require(up.tipSwitchActive, "real zero BT sample should keep writing while TX1 still indicates down");
 #if EGOTOUCH_DIAG
     Require(up.diag.pressureIsReal, "real zero frame should still be marked as real");
 #endif
@@ -660,7 +684,7 @@ int main() {
         TestFakePressureDecayReset();
         TestNoPressInkGateEnterAndExit();
         TestStylusPipelineNoPressSyntheticPressure();
-        TestStylusPipelineLowSignalPressureSuppress();
+        TestStylusPipelineLowSignalKeepsCoordinateButZeroPressureUntilAuthoritativeDown();
         TestStylusPipelineFastLiftToNoSignal();
         TestStylusPipelineReleaseRetainsPreviousOutput();
         TestStylusPipelineEdgeFastLiftRetainsCoordinate();
@@ -673,7 +697,7 @@ int main() {
         TestGridPeakDetectorProjectionRadius();
         TestStylusPipelinePeakMetrics();
         TestStylusPipelineUsesPredictedIntermediatePressure();
-        TestStylusPipelineRealZeroReleasesQuickly();
+        TestStylusPipelineRealZeroDropsPressureButKeepsWritingWhenTx1StillDown();
         std::cout << "[TEST] Stylus fast ink tests passed.\n";
         return 0;
     } catch (const std::exception& ex) {

--- a/Tools/tests/TouchTrackerStylusSuppressTest.cpp
+++ b/Tools/tests/TouchTrackerStylusSuppressTest.cpp
@@ -107,6 +107,17 @@ void TestWeakTouchNearStylusIsSuppressedUsingStylusCoordinates() {
     Require(frame.stylus.touchSuppressFrames > 0, "suppress hold should be armed");
 }
 
+void TestZeroPressureWritingStillSuppressesWeakOverlapTouch() {
+    TrackerHarness harness;
+    const StylusSpec stylus = MakeStylusSpec(true, 12.5f, 7.75f, 0, 500, 2200, 2);
+    const auto frame = harness.Run({
+        ContactSpec{12.55f, 7.80f, 3, 160, 0.8f}
+    }, stylus);
+
+    Require(frame.contacts.empty(), "writing animState should suppress weak overlap even at zero pressure");
+    Require(frame.stylus.touchSuppressActive, "touch suppress should stay active when animState indicates writing");
+}
+
 void TestStrongTouchNearStylusIsPreserved() {
     TrackerHarness harness;
     const StylusSpec stylus = MakeStylusSpec(true, 18.0f, 12.0f, 160, 700, 2100, 2);
@@ -157,6 +168,7 @@ void TestAftKeepsSuppressingRecentWeakTouchAfterStylusLeaves() {
 int main() {
     try {
         TestWeakTouchNearStylusIsSuppressedUsingStylusCoordinates();
+        TestZeroPressureWritingStillSuppressesWeakOverlapTouch();
         TestStrongTouchNearStylusIsPreserved();
         TestFarTouchIsNotMisSuppressed();
         TestAftKeepsSuppressingRecentWeakTouchAfterStylusLeaves();


### PR DESCRIPTION
## Summary
- adjust stylus state/pressure gating and related solver behavior paths
- refine touch suppression behavior under stylus-writing edge conditions
- update fast-ink and suppress regression tests to lock new behavior

## Test plan
- [x] cmake --build build --config Release --target Solvers StylusPipelineFastInkTest TouchTrackerStylusSuppressTest TouchPipelineConfigRoundTripTest
- [x] ctest --test-dir build -R "StylusPipelineFastInkTest|TouchTrackerStylusSuppressTest|TouchPipelineConfigRoundTripTest" --output-on-failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)