### PR TITLE
Optimize service release logger memory use

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,3 +2,6 @@
 
 ## 项目指南
 - 在此工作区中，Visual Studio CMake 使用 clang-cl 时不要只依赖 inheritEnvironments；需要显式避免解析到 x86 版本 clang-cl。
+
+## DVR 分析指南
+- 在 EGoTouchRev DVR 分析中，用户所说的“rawdata/原始数据”主要指 DVR 帧中的 heatmap 原始矩阵数据，不应仅按 rawDataLength/raw.hex 独立字节块判断；录制 rawdata 时可能不存在手指解算出的 contacts/peaks。

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ target_include_directories(Common PUBLIC
 # Forward-declare include path; Solvers target linked below after Solvers is defined
 target_link_libraries(Common PUBLIC spdlog::spdlog)
 target_compile_definitions(Common PRIVATE
+    $<$<CONFIG:Debug>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE>
     $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
     $<$<CONFIG:Release>:EGOTOUCH_LOGGER_SYNC_FILE_ONLY=1>
 )
@@ -235,6 +236,7 @@ target_compile_definitions(Device PUBLIC
     $<$<NOT:$<BOOL:${HIMAX_ENABLE_NEON}>>:HIMAX_ENABLE_NEON=0>
 )
 target_compile_definitions(Device PRIVATE
+    $<$<CONFIG:Debug>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE>
     $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
 )
 
@@ -258,6 +260,7 @@ function(ego_configure_solvers_target target)
         $<$<NOT:$<BOOL:${HIMAX_ENABLE_NEON}>>:HIMAX_ENABLE_NEON=0>
     )
     target_compile_definitions(${target} PRIVATE
+        $<$<CONFIG:Debug>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE>
         $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
     )
     target_include_directories(${target} PUBLIC
@@ -288,6 +291,7 @@ add_library(Host STATIC
 target_include_directories(Host PUBLIC "${HOST_ROOT}")
 target_link_libraries(Host PUBLIC Common)
 target_compile_definitions(Host PRIVATE
+    $<$<CONFIG:Debug>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE>
     $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
 )
 if (WIN32)
@@ -380,6 +384,7 @@ target_compile_definitions(EGoTouchServiceCore PUBLIC
     EGOTOUCH_SERVICE_ENABLE_IPC=$<IF:$<CONFIG:Debug>,1,0>
 )
 target_compile_definitions(EGoTouchServiceCore PRIVATE
+    $<$<CONFIG:Debug>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE>
     $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
 )
 
@@ -394,6 +399,7 @@ target_include_directories(EGoTouchService PRIVATE
 target_link_libraries(EGoTouchService PRIVATE EGoTouchServiceCore $<$<CONFIG:Debug>:IPCCore> Device Host Common advapi32 setupapi hid)
 target_compile_definitions(EGoTouchService PRIVATE
     EGOTOUCH_SERVICE_ENABLE_IPC=$<IF:$<CONFIG:Debug>,1,0>
+    $<$<CONFIG:Debug>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE>
     $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,7 @@ target_include_directories(EGoTouchService PRIVATE
 target_link_libraries(EGoTouchService PRIVATE EGoTouchServiceCore $<$<CONFIG:Debug>:IPCCore> Device Host Common advapi32 setupapi hid)
 target_compile_definitions(EGoTouchService PRIVATE
     EGOTOUCH_SERVICE_ENABLE_IPC=$<IF:$<CONFIG:Debug>,1,0>
+    $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
 )
 ego_copy_config_to_output(EGoTouchService)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,10 @@ target_include_directories(Common PUBLIC
 # Common links Solvers for SharedFrameBuffer (EngineTypes.h)
 # Forward-declare include path; Solvers target linked below after Solvers is defined
 target_link_libraries(Common PUBLIC spdlog::spdlog)
+target_compile_definitions(Common PRIVATE
+    $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
+    $<$<CONFIG:Release>:EGOTOUCH_LOGGER_SYNC_FILE_ONLY=1>
+)
 
 # 启用预编译头 (PCH) 以减少编译时的重复解析开销
 target_precompile_headers(Common PRIVATE
@@ -230,6 +234,9 @@ target_compile_definitions(Device PUBLIC
     $<$<BOOL:${HIMAX_ENABLE_NEON}>:HIMAX_ENABLE_NEON=1>
     $<$<NOT:$<BOOL:${HIMAX_ENABLE_NEON}>>:HIMAX_ENABLE_NEON=0>
 )
+target_compile_definitions(Device PRIVATE
+    $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
+)
 
 target_include_directories(Device PUBLIC
     "${DEVICE_ROOT}"
@@ -249,6 +256,9 @@ function(ego_configure_solvers_target target)
     target_compile_definitions(${target} PUBLIC
         $<$<BOOL:${HIMAX_ENABLE_NEON}>:HIMAX_ENABLE_NEON=1>
         $<$<NOT:$<BOOL:${HIMAX_ENABLE_NEON}>>:HIMAX_ENABLE_NEON=0>
+    )
+    target_compile_definitions(${target} PRIVATE
+        $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
     )
     target_include_directories(${target} PUBLIC
         "${SOLVERS_ROOT}"
@@ -277,6 +287,9 @@ add_library(Host STATIC
 )
 target_include_directories(Host PUBLIC "${HOST_ROOT}")
 target_link_libraries(Host PUBLIC Common)
+target_compile_definitions(Host PRIVATE
+    $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
+)
 if (WIN32)
     target_link_libraries(Host PUBLIC advapi32)
 endif()
@@ -366,6 +379,9 @@ target_link_libraries(EGoTouchServiceCore PUBLIC Common Solvers $<$<CONFIG:Debug
 target_compile_definitions(EGoTouchServiceCore PUBLIC
     EGOTOUCH_SERVICE_ENABLE_IPC=$<IF:$<CONFIG:Debug>,1,0>
 )
+target_compile_definitions(EGoTouchServiceCore PRIVATE
+    $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
+)
 
 add_executable(EGoTouchService
     "${SERVICE_ROOT}/source/ServiceEntry.cpp"
@@ -380,6 +396,7 @@ target_compile_definitions(EGoTouchService PRIVATE
     EGOTOUCH_SERVICE_ENABLE_IPC=$<IF:$<CONFIG:Debug>,1,0>
     $<$<CONFIG:Release>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO>
 )
+
 ego_copy_config_to_output(EGoTouchService)
 
 install(TARGETS EGoTouchService

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -44,7 +44,11 @@
       "displayName": "arm64 Debug",
       "inherits": "arm64-base",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "EGO_BUILD_TOOLS": {
+          "type": "BOOL",
+          "value": "ON"
+        }
       }
     },
     {

--- a/Common/include/Logger.h
+++ b/Common/include/Logger.h
@@ -56,8 +56,18 @@ private:
     }
 
 // 暴露给业务层使用的便捷宏
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
 #define LOG_TRACE(layer, method, state, msg, ...) LOG_INTERNAL(trace, layer, method, state, msg __VA_OPT__(,) __VA_ARGS__)
+#else
+#define LOG_TRACE(layer, method, state, msg, ...) (void)0
+#endif
+
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
 #define LOG_DEBUG(layer, method, state, msg, ...) LOG_INTERNAL(debug, layer, method, state, msg __VA_OPT__(,) __VA_ARGS__)
+#else
+#define LOG_DEBUG(layer, method, state, msg, ...) (void)0
+#endif
+
 #define LOG_INFO(layer,  method, state, msg, ...) LOG_INTERNAL(info,  layer, method, state, msg __VA_OPT__(,) __VA_ARGS__)
 #define LOG_WARN(layer,  method, state, msg, ...) LOG_INTERNAL(warn,  layer, method, state, msg __VA_OPT__(,) __VA_ARGS__)
 #define LOG_ERROR(layer, method, state, msg, ...) LOG_INTERNAL(error, layer, method, state, msg __VA_OPT__(,) __VA_ARGS__)

--- a/Common/source/Logger.cpp
+++ b/Common/source/Logger.cpp
@@ -3,14 +3,20 @@
  * @brief 通用日志模块实现
  */
 #include "Logger.h"
+
+#include <spdlog/async.h>
+#include <spdlog/async_logger.h>
+#include <spdlog/sinks/daily_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+
 #include <iostream>
+#include <system_error>
+#include <vector>
 
 namespace Common {
 
 namespace {
-#ifndef NDEBUG
 constexpr std::size_t kAsyncQueueSize = 8192;
-#endif
 } // namespace
 
 std::shared_ptr<spdlog::logger> Logger::s_logger = nullptr;
@@ -31,35 +37,41 @@ void Logger::Init(const std::string& loggerName, const std::filesystem::path& lo
             return;
         }
 
+#if defined(EGOTOUCH_LOGGER_SYNC_FILE_ONLY) && (EGOTOUCH_LOGGER_SYNC_FILE_ONLY == 1)
+        const bool syncFileOnly = (loggerName == "EGoTouchService");
+#else
+        constexpr bool syncFileOnly = false;
+#endif
+
         // Daily File Sink (每天午夜轮转，最多保留 3 个文件)
         fs::path file_path = logDir / (loggerName + ".txt");
         auto file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(file_path.string(), 0, 0, false, 3);
         file_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%-7l] %v");
 
-#ifndef NDEBUG
-        // 初始化异步日志线程池
-        spdlog::init_thread_pool(kAsyncQueueSize, 1);
+        if (!syncFileOnly) {
+            // 初始化异步日志线程池
+            spdlog::init_thread_pool(kAsyncQueueSize, 1);
 
-        // Console Sink (带颜色)
-        auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-        // 格式: [%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v
-        console_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%-7l%$] %v");
+            // Console Sink (带颜色)
+            auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+            // 格式: [%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v
+            console_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%-7l%$] %v");
 
-        std::vector<spdlog::sink_ptr> sinks {console_sink, file_sink};
-        if (extraSink) sinks.push_back(extraSink);
+            std::vector<spdlog::sink_ptr> sinks {console_sink, file_sink};
+            if (extraSink) sinks.push_back(extraSink);
 
-        // 创建异步 Logger
-        s_logger = std::make_shared<spdlog::async_logger>(
-            loggerName,
-            sinks.begin(), sinks.end(),
-            spdlog::thread_pool(),
-            spdlog::async_overflow_policy::block
-        );
-#else
-        s_logger = std::make_shared<spdlog::logger>(loggerName, file_sink);
-#endif
+            // 创建异步 Logger
+            s_logger = std::make_shared<spdlog::async_logger>(
+                loggerName,
+                sinks.begin(), sinks.end(),
+                spdlog::thread_pool(),
+                spdlog::async_overflow_policy::block
+            );
+        } else {
+            s_logger = std::make_shared<spdlog::logger>(loggerName, file_sink);
+        }
 
-        s_logger->set_level(spdlog::level::trace);
+        s_logger->set_level(syncFileOnly ? spdlog::level::info : spdlog::level::trace);
         s_logger->flush_on(spdlog::level::info);
 
         spdlog::register_logger(s_logger);

--- a/Common/source/Logger.cpp
+++ b/Common/source/Logger.cpp
@@ -8,12 +8,8 @@
 namespace Common {
 
 namespace {
-constexpr std::size_t kDebugAsyncQueueSize = 8192;
-constexpr std::size_t kReleaseAsyncQueueSize = 2048;
-#if defined(NDEBUG)
-constexpr std::size_t kAsyncQueueSize = kReleaseAsyncQueueSize;
-#else
-constexpr std::size_t kAsyncQueueSize = kDebugAsyncQueueSize;
+#ifndef NDEBUG
+constexpr std::size_t kAsyncQueueSize = 8192;
 #endif
 } // namespace
 
@@ -35,29 +31,33 @@ void Logger::Init(const std::string& loggerName, const std::filesystem::path& lo
             return;
         }
 
-        // 初始化异步日志线程池
-        spdlog::init_thread_pool(kAsyncQueueSize, 1);
-
-        // 1. Console Sink (带颜色)
-        auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-        // 格式: [%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v
-        console_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%-7l%$] %v");
-
-        // 2. Daily File Sink (每天午夜轮转，最多保留 3 个文件)
+        // Daily File Sink (每天午夜轮转，最多保留 3 个文件)
         fs::path file_path = logDir / (loggerName + ".txt");
         auto file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(file_path.string(), 0, 0, false, 3);
         file_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%-7l] %v");
+
+#ifndef NDEBUG
+        // 初始化异步日志线程池
+        spdlog::init_thread_pool(kAsyncQueueSize, 1);
+
+        // Console Sink (带颜色)
+        auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+        // 格式: [%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v
+        console_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%-7l%$] %v");
 
         std::vector<spdlog::sink_ptr> sinks {console_sink, file_sink};
         if (extraSink) sinks.push_back(extraSink);
 
         // 创建异步 Logger
         s_logger = std::make_shared<spdlog::async_logger>(
-            loggerName, 
-            sinks.begin(), sinks.end(), 
-            spdlog::thread_pool(), 
+            loggerName,
+            sinks.begin(), sinks.end(),
+            spdlog::thread_pool(),
             spdlog::async_overflow_policy::block
         );
+#else
+        s_logger = std::make_shared<spdlog::logger>(loggerName, file_sink);
+#endif
 
         s_logger->set_level(spdlog::level::trace);
         s_logger->flush_on(spdlog::level::info);

--- a/EGoTouchService/Solvers/StylusSolver/shared/CoorIIRProcess.hpp
+++ b/EGoTouchService/Solvers/StylusSolver/shared/CoorIIRProcess.hpp
@@ -18,11 +18,11 @@ public:
     int32_t m_speedTholdHover = 20;  // 0x14
 
     // Writing mode params (has pressure)
-    int32_t m_coefLowWriting = 6;        // asa[0xA5C]
-    int32_t m_coefHighWriting = 18;      // asa[0xA5D]
+    int32_t m_coefLowWriting = 18;        // asa[0xA5C]
+    int32_t m_coefHighWriting = 26;      // asa[0xA5D]
     int32_t m_speedTholdWriting = 10;    // 0x0A
 
-    int32_t m_speedMax = 140;  // 0xCD — speed value at which high coef is fully engaged
+    int32_t m_speedMax = 60;  // 0xCD — speed value at which high coef is fully engaged
     int32_t m_maxCoef = 32;    // asa[0xA60] — denominator in IIR formula
 
     // ── Output ──


### PR DESCRIPTION
## What changed
- Switch  Release logging to a synchronous file-only logger path guarded by .
- Avoid initializing the spdlog async thread pool / async logger for the Service Release logger, removing the async queue allocation.
- Make project  /  respect , with Service Release set to info-level裁剪 and Debug preserving trace logging.
- Keep Debug logging behavior as async + console + file + optional , and avoid forcing App/Tools Release loggers into Service file-only mode.

## Why
Service Release does not use App/DVR/IPC debug logging paths, so the async logger queue is unnecessary runtime memory overhead for the production service. This reduces baseline private memory while preserving Debug diagnostics.

## Verification
- ninja: no work to do.
- -- Checking/Generating .clangd config for clangd language server...
-- Auto-generated .clangd config successfully at: D:/source/repos/EGoTouchRev-rebuild/.clangd
-- Link-Time Optimization (LTO/IPO) is supported. Enabling for Release configuration...
-- Build spdlog: 1.17.0
-- Build type: Debug
-- Configuring done (5.9s)
-- Generating done (0.5s)
-- Build files have been written to: D:/source/repos/EGoTouchRev-rebuild/build/arm64-Debug
- [1/8] Linking CXX static library spdlog_build\spdlogd.lib
[2/8] Linking CXX static library Common.lib
[3/8] Linking CXX static library IPCCore.lib
[4/8] Linking CXX static library Solvers.lib
[5/8] Linking CXX static library Host.lib
[6/8] Linking CXX static library EGoTouchServiceCore.lib
[7/8] Linking CXX static library Device.lib
[8/8] Linking CXX executable EGoTouchService.exe
- 

🤖 Generated with [Claude Code](https://claude.com/claude-code)